### PR TITLE
Add in gemini CLI config instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,29 @@ Add to `~/.kiro/settings/mcp.json`:
 }
 ```
 
+#### Gemini CLI
+
+It is recommended to use a project-local configuration file to ensure the relevant workspace is mounted.
+
+Add to `.gemini/settings.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "arm-mcp": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-v", "/path/to/your/workspace:/workspace",
+        "arm-mcp"
+      ]
+    }
+  }
+}
+```
+
 #### MCP Clients using TOML format (e.g. Codex CLI)
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ If you would prefer to use a pre-built, multi-arch image, the official image can
 From the root of this repository:
 
 ```bash
-docker buildx build --platform linux/arm64,linux/amd64 -f mcp-local/Dockerfile -t arm-mcp mcp-local
+docker buildx build --platform linux/arm64,linux/amd64 -f mcp-local/Dockerfile -t armlimited/arm-mcp mcp-local
 ```
 
 For a single-platform build (faster):
 
 ```bash
-docker buildx build -f mcp-local/Dockerfile -t arm-mcp mcp-local
+docker buildx build -f mcp-local/Dockerfile -t armlimited/arm-mcp mcp-local
 ```
 
 ### 2. Configure Your MCP Client
@@ -56,7 +56,7 @@ Add to `.vscode/mcp.json` in your project, or globally at `~/Library/Application
         "--rm",
         "-i",
         "-v", "/path/to/your/workspace:/workspace",
-        "arm-mcp"
+        "armlimited/arm-mcp"
       ]
     }
   }
@@ -82,7 +82,7 @@ Add to `~/.kiro/settings/mcp.json`:
         "-i",
         "-v", "/path/to/your/workspace:/workspace",
         "--name", "arm-mcp",
-        "arm-mcp"
+        "armlimited/arm-mcp"
       ],
       "timeout": 60000
     }
@@ -106,7 +106,7 @@ Add to `.gemini/settings.json` in your project root:
         "--rm",
         "-i",
         "-v", "/path/to/your/workspace:/workspace",
-        "arm-mcp"
+        "armlimited/arm-mcp"
       ]
     }
   }
@@ -123,7 +123,7 @@ args = [
   "--rm",
   "-i",
   "-v", "/path/to/your/workspace:/workspace",
-  "arm-mcp"
+  "armlimited/arm-mcp"
 ]
 ```
 
@@ -149,7 +149,7 @@ After updating the configuration, restart your MCP client to load the Arm MCP se
 To debug or explore the container environment:
 
 ```bash
-docker run --rm -it --entrypoint /bin/bash arm-mcp
+docker run --rm -it --entrypoint /bin/bash armlimited/arm-mcp
 ```
 
 ### Common Issues


### PR DESCRIPTION
Also use armlimited/arm-mcp as docker image name for consistency, esp if user opts not to build image themselves