### PR TITLE
Embeddings and multi-arch workflows

### DIFF
--- a/.github/workflows/build-embeddings.yml
+++ b/.github/workflows/build-embeddings.yml
@@ -1,0 +1,41 @@
+name: Build Embeddings Image
+
+on:
+  schedule:
+    - cron: "0 9 * * 0"
+  workflow_dispatch:
+
+jobs:
+  build-embeddings:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set build date (UTC)
+        run: echo "BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push embeddings image
+        uses: docker/build-push-action@v5
+        with:
+          context: embedding-generation
+          file: Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: |
+            armlimited/arm-mcp:embeddings-${{ env.BUILD_DATE }}
+            armlimited/arm-mcp:embeddings-latest
+          build-args: |
+            EMBEDDING_BASE_IMAGE=armlimited/arm-mcp:mcp-embedding-base

--- a/.github/workflows/build-mcp-image.yml
+++ b/.github/workflows/build-mcp-image.yml
@@ -1,0 +1,87 @@
+name: Build MCP Image
+
+on:
+  workflow_run:
+    workflows: ["Build Embeddings Image"]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  build-arch-images:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+            tag: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            tag: arm64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      build_date: ${{ steps.build_date.outputs.build_date }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set build date (UTC)
+        id: build_date
+        run: |
+          if [ -n "${{ github.event.workflow_run.created_at }}" ]; then
+            BUILD_DATE=$(date -u -d "${{ github.event.workflow_run.created_at }}" +%Y-%m-%d)
+          else
+            BUILD_DATE=$(date -u +%Y-%m-%d)
+          fi
+          echo "BUILD_DATE=$BUILD_DATE" >> "$GITHUB_ENV"
+          echo "build_date=$BUILD_DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.platform }} image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: mcp-local/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: armlimited/arm-mcp:${{ env.BUILD_DATE }}-${{ matrix.tag }}
+          build-args: |
+            EMBEDDINGS_IMAGE=armlimited/arm-mcp:embeddings-${{ env.BUILD_DATE }}
+
+  merge-manifests:
+    needs: build-arch-images
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    if: ${{ needs.build-arch-images.result == 'success' }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch manifest for date tag
+        env:
+          BUILD_DATE: ${{ needs.build-arch-images.outputs.build_date }}
+        run: |
+          docker buildx imagetools create \
+            -t armlimited/arm-mcp:${{ env.BUILD_DATE }} \
+            armlimited/arm-mcp:${{ env.BUILD_DATE }}-amd64 \
+            armlimited/arm-mcp:${{ env.BUILD_DATE }}-arm64

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -r mcp-local/tests/requirements.txt
 
       - name: Build MCP Docker image
-        run:  docker buildx build -f mcp-local/Dockerfile -t arm-mcp .
+        run: docker buildx build -f mcp-local/Dockerfile -t arm-mcp --build-arg EMBEDDINGS_IMAGE=armlimited/arm-mcp:embeddings-latest .
 
       - name: Run integration tests
         env:

--- a/embedding-generation/Dockerfile
+++ b/embedding-generation/Dockerfile
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Base image containing intrinsic chunks data
-FROM ubuntu:24.04
+# syntax=docker/dockerfile:1.7
 
-ENV DEBIAN_FRONTEND=noninteractive
+ARG EMBEDDING_BASE_IMAGE=armlimited/arm-mcp:mcp-embedding-base
+FROM ${EMBEDDING_BASE_IMAGE} AS intrinsic-chunks
+
+FROM ubuntu:24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_INDEX_URL=https://download.pytorch.org/whl/cpu \
+    PIP_EXTRA_INDEX_URL=https://pypi.org/simple
 
 # Install Python
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -24,14 +30,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /embedding-data
 
-# Copy intrinsic chunks data
-COPY intrinsic_chunks/ ./intrinsic_chunks/
-
 # Copy Python scripts and dependencies
 COPY generate-chunks.py .
 COPY local_vectorstore_creation.py .
 COPY urls-to-chunk.csv .
 COPY requirements.txt .
 
-# Install Python dependencies
+# Copy intrinsic chunks data from the cached base image
+COPY --from=intrinsic-chunks /embedding-data/intrinsic_chunks ./intrinsic_chunks
+
+# Install Python dependencies (force CPU-only torch)
 RUN pip3 install --no-cache-dir --break-system-packages -r requirements.txt
+
+# Generate vector database
+RUN python3 generate-chunks.py urls-to-chunk.csv && \
+    python3 local_vectorstore_creation.py && \
+    rm -f embeddings_*.txt
+
+FROM scratch AS embeddings
+
+COPY --from=builder /embedding-data/metadata.json /embedding-data/metadata.json
+COPY --from=builder /embedding-data/usearch_index.bin /embedding-data/usearch_index.bin

--- a/mcp-local/Dockerfile
+++ b/mcp-local/Dockerfile
@@ -14,7 +14,11 @@
 
 # syntax=docker/dockerfile:1.7
 
-# Stage 1: Build main application with embedded vector database generation
+ARG EMBEDDINGS_IMAGE
+# EMBEDDINGS_IMAGE must point to an embeddings image tag (e.g., armlimited/arm-mcp:embeddings-YYYY-MM-DD).
+FROM --platform=linux/arm64 ${EMBEDDINGS_IMAGE} AS embeddings
+
+# Stage 1: Build main application with prebuilt vector database
 FROM ubuntu:24.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -43,22 +47,6 @@ RUN rm -f /usr/local/bin/aperf \
            /opt/arm-migration-tools/processwatch \
            /opt/arm-migration-tools/papi
 
-COPY embedding-generation/generate-chunks.py /tmp/embedding-generation/generate-chunks.py
-COPY embedding-generation/local_vectorstore_creation.py /tmp/embedding-generation/local_vectorstore_creation.py
-COPY embedding-generation/requirements.txt /tmp/embedding-generation/requirements.txt
-COPY embedding-generation/urls-to-chunk.csv /tmp/embedding-generation/urls-to-chunk.csv
-
-# Copy embedding data and scripts from the embedding base image
-COPY --from=joestech324/mcp-embedding-base:latest /embedding-data/intrinsic_chunks /tmp/embedding-generation/intrinsic_chunks
-
-# Install dependencies for vector database generation
-WORKDIR /tmp/embedding-generation
-RUN pip3 install --no-cache-dir --break-system-packages -r requirements.txt
-
-# Generate vector database
-RUN python3 generate-chunks.py urls-to-chunk.csv && \
-    python3 local_vectorstore_creation.py
-
 # Set up MCP server application
 WORKDIR /app
 ENV VIRTUAL_ENV=/app/.venv \
@@ -67,12 +55,20 @@ ENV VIRTUAL_ENV=/app/.venv \
 RUN python3 -m venv "$VIRTUAL_ENV" && pip install --upgrade pip
 
 COPY mcp-local/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+ARG TARGETPLATFORM
+# Install dependencies (force CPU-only torch on amd64)
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+        PIP_INDEX_URL=https://download.pytorch.org/whl/cpu \
+        PIP_EXTRA_INDEX_URL=https://pypi.org/simple \
+        pip install --no-cache-dir -r requirements.txt; \
+    else \
+        pip install --no-cache-dir -r requirements.txt; \
+    fi
 
 # Copy generated vector database files
 RUN mkdir -p ./data
-RUN cp /tmp/embedding-generation/metadata.json ./data/ && \
-    cp /tmp/embedding-generation/usearch_index.bin ./data/
+COPY --from=embeddings /embedding-data/metadata.json ./data/metadata.json
+COPY --from=embeddings /embedding-data/usearch_index.bin ./data/usearch_index.bin
 
 COPY mcp-local/utils/ ./utils/
 COPY mcp-local/server.py .

--- a/mcp-local/Dockerfile
+++ b/mcp-local/Dockerfile
@@ -16,7 +16,7 @@
 
 ARG EMBEDDINGS_IMAGE=armlimited/arm-mcp:embeddings-latest
 # EMBEDDINGS_IMAGE must point to an embeddings image tag (e.g., armlimited/arm-mcp:embeddings-YYYY-MM-DD).
-FROM --platform=linux/arm64 ${EMBEDDINGS_IMAGE} AS embeddings
+FROM ${EMBEDDINGS_IMAGE} AS embeddings
 
 # Stage 1: Build main application with prebuilt vector database
 FROM ubuntu:24.04 AS builder

--- a/mcp-local/Dockerfile
+++ b/mcp-local/Dockerfile
@@ -14,7 +14,7 @@
 
 # syntax=docker/dockerfile:1.7
 
-ARG EMBEDDINGS_IMAGE
+ARG EMBEDDINGS_IMAGE=armlimited/arm-mcp:embeddings-latest
 # EMBEDDINGS_IMAGE must point to an embeddings image tag (e.g., armlimited/arm-mcp:embeddings-YYYY-MM-DD).
 FROM --platform=linux/arm64 ${EMBEDDINGS_IMAGE} AS embeddings
 


### PR DESCRIPTION
Make embeddings build separate and use two different runners to build the multi-arch main image.

Embeddings will now rebuild every Sunday morning, and use a static baseimage containing the intrinsics that is not a joestech324 image.

QEMU emulation no longer used, due to using separate arch runners and merging the manifests in a step at the end. This fixes extremely long build runs.