### PR TITLE
Add UTM source to KB result links

### DIFF
--- a/arm_kb_search/__init__.py
+++ b/arm_kb_search/__init__.py
@@ -42,11 +42,15 @@ from .resources import (
 from .response import (
     ARM_CONTENT_DISCLAIMER,
     add_disclaimer_to_arm_results,
+    add_utm_source_to_results,
+    add_utm_source_to_url,
     is_arm_domain_url,
 )
 
 __all__ = [
     "add_disclaimer_to_arm_results",
+    "add_utm_source_to_results",
+    "add_utm_source_to_url",
     "ARM_CONTENT_DISCLAIMER",
     "build_bm25_index",
     "bm25_search",

--- a/arm_kb_search/resources.py
+++ b/arm_kb_search/resources.py
@@ -22,7 +22,7 @@ from usearch.index import Index
 
 from .config import K_RESULTS
 from .loaders import load_metadata, load_usearch_index
-from .response import add_disclaimer_to_arm_results
+from .response import add_disclaimer_to_arm_results, add_utm_source_to_results
 from .search import build_bm25_index, deduplicate_urls, hybrid_search
 
 
@@ -34,6 +34,7 @@ class SearchResources:
     bm25_index: BM25Okapi | None
     default_k: int = K_RESULTS
     include_disclaimers: bool = True
+    utm_source: str | None = None
 
 
 def sentence_transformer_cache_folder() -> str | None:
@@ -76,6 +77,7 @@ def load_search_resources(
     local_files_only_first: bool = True,
     default_k: int = K_RESULTS,
     include_disclaimers: bool = True,
+    utm_source: str | None = None,
 ) -> SearchResources:
     metadata = load_metadata(metadata_path)
     embedding_model = load_embedding_model(
@@ -95,6 +97,7 @@ def load_search_resources(
         bm25_index=bm25_index,
         default_k=default_k,
         include_disclaimers=include_disclaimers,
+        utm_source=utm_source,
     )
 
 
@@ -126,6 +129,7 @@ def search(
         }
         for item in deduped
     ]
+    formatted = add_utm_source_to_results(formatted, resources.utm_source)
     if resources.include_disclaimers:
         return add_disclaimer_to_arm_results(formatted)
     return formatted

--- a/arm_kb_search/response.py
+++ b/arm_kb_search/response.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from typing import Any, Dict, List
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 
 ARM_CONTENT_DISCLAIMER = (
@@ -40,5 +40,32 @@ def is_arm_domain_url(url: str | None) -> bool:
 def add_disclaimer_to_arm_results(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return [
         {**item, "disclaimer": ARM_CONTENT_DISCLAIMER} if is_arm_domain_url(item.get("url")) else item
+        for item in results
+    ]
+
+
+def add_utm_source_to_url(url: str | None, utm_source: str | None) -> str | None:
+    if not url or not utm_source:
+        return url
+
+    parsed = urlparse(url)
+    query_params = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key != "utm_source"
+    ]
+    query_params.append(("utm_source", utm_source))
+    return urlunparse(parsed._replace(query=urlencode(query_params)))
+
+
+def add_utm_source_to_results(
+    results: List[Dict[str, Any]],
+    utm_source: str | None,
+) -> List[Dict[str, Any]]:
+    if not utm_source:
+        return results
+
+    return [
+        {**item, "url": add_utm_source_to_url(item.get("url"), utm_source)} if "url" in item else item
         for item in results
     ]

--- a/mcp-local/server.py
+++ b/mcp-local/server.py
@@ -40,6 +40,7 @@ SEARCH_RESOURCES = arm_kb_search.load_search_resources(
     metadata_path=METADATA_PATH,
     usearch_index_path=USEARCH_INDEX_PATH,
     model_name=MODEL_NAME,
+    utm_source="arm-mcp",
 )
 
 


### PR DESCRIPTION
Adds utm_source=arm-mcp to all KB search result URLs.

Examples:
https://learn.arm.com/migration
→ https://learn.arm.com/migration?utm_source=arm-mcp

https://www.arm.com/developer-hub/ecosystem-dashboard/?package=curl
→ https://www.arm.com/developer-hub/ecosystem-dashboard/?package=curl&utm_source=arm-mcp

Testing done:
Built local Docker image arm-mcp:utm-test and verified real KB search results include utm_source=arm-mcp across plain URLs and URLs with existing query params.