### PR TITLE
[STESOL-554] Have eval script use main search function and add sources to eval answers

### DIFF
--- a/arm_kb_search/resources.py
+++ b/arm_kb_search/resources.py
@@ -113,6 +113,7 @@ def search(
     k: int | None = None,
 ) -> list[dict[str, Any]]:
     resolved_k = k or resources.default_k
+    candidate_depth = max(resolved_k * 20, 100)
     search_results = hybrid_search(
         query,
         resources.usearch_index,
@@ -120,6 +121,7 @@ def search(
         resources.embedding_model,
         resources.bm25_index,
         k=deduplication_candidate_count(resolved_k),
+        candidate_depth=candidate_depth,
     )
     deduped = deduplicate_urls(search_results)[:resolved_k]
     formatted = [

--- a/embedding-generation/eval_questions.json
+++ b/embedding-generation/eval_questions.json
@@ -212,7 +212,8 @@
   {
     "question": "What does the Arm Performix Code Hotspots recipe show, and how should I interpret the top hotspots, flame graphs, function tables, CPU usage, and source line attribution?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/110163/latest/About-Arm-Performix/Basic-concepts/Code-Hotspots-recipe/Interpreting-and-using-the-results?lang=en"
+      "https://developer.arm.com/documentation/110163/latest/About-Arm-Performix/Basic-concepts/Code-Hotspots-recipe/Interpreting-and-using-the-results?lang=en",
+      "https://learn.arm.com/learning-paths/servers-and-cloud-computing/cpu_hotspot_performix/"
     ]
   },
   {
@@ -1154,7 +1155,8 @@
   {
     "question": "How do I get started with Arm Performance Studio?",
     "expected_urls": [
-      "https://learn.arm.com/learning-paths/mobile-graphics-and-gaming/ams/"
+      "https://learn.arm.com/learning-paths/mobile-graphics-and-gaming/ams/",
+      "https://learn.arm.com/install-guides/ams/"
     ]
   },
   {
@@ -2162,7 +2164,8 @@
   {
     "question": "How do I tune MySQL?",
     "expected_urls": [
-      "https://learn.arm.com/learning-paths/servers-and-cloud-computing/mysql_tune/"
+      "https://learn.arm.com/learning-paths/servers-and-cloud-computing/mysql_tune/",
+      "https://amperecomputing.com/tuning-guides/mysql-tuning-guide"
     ]
   },
   {

--- a/embedding-generation/evaluate_retrieval.py
+++ b/embedding-generation/evaluate_retrieval.py
@@ -3,63 +3,34 @@
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 from pathlib import Path
-
-from sentence_transformers import SentenceTransformer
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from arm_kb_search import (  # noqa: E402
-    build_bm25_index,
-    deduplicate_urls,
-    deduplication_candidate_count,
-    embedding_dimension,
-    hybrid_search,
-    load_metadata,
-    load_usearch_index,
+    load_search_resources,
+    search,
 )
 from arm_kb_search.evaluation import evaluate_retrieval, load_eval_rows, print_evaluation  # noqa: E402
 
 
-def sentence_transformer_cache_folder() -> str | None:
-    return os.getenv("SENTENCE_TRANSFORMERS_HOME") or None
-
-
 def evaluate(index_path: Path, metadata_path: Path, eval_path: Path, model_name: str, top_k: int) -> int:
-    metadata = load_metadata(str(metadata_path))
-    if not metadata:
+    if not metadata_path.exists() or metadata_path.stat().st_size == 0:
         print(f"Metadata not found or empty: {metadata_path}")
         return 1
 
-    embedding_model = SentenceTransformer(
-        model_name,
-        cache_folder=sentence_transformer_cache_folder(),
-        local_files_only=True,
+    resources = load_search_resources(
+        metadata_path=str(metadata_path),
+        usearch_index_path=str(index_path),
+        model_name=model_name,
     )
-    usearch_index = load_usearch_index(
-        str(index_path),
-        embedding_dimension(embedding_model),
-    )
-    bm25_index = build_bm25_index(metadata)
     eval_rows = load_eval_rows(eval_path)
 
     def retrieve_urls(question: str, top_k: int) -> list[str | None]:
-        raw_results = hybrid_search(
-            question,
-            usearch_index,
-            metadata,
-            embedding_model,
-            bm25_index,
-            k=deduplication_candidate_count(top_k),
-            candidate_depth=max(top_k * 20, 100),
-        )
-        results = deduplicate_urls(raw_results, max_chunks_per_url=1)[:top_k]
-        return [item["metadata"].get("url") for item in results]
+        return [item.get("url") for item in search(question, resources, k=top_k)]
 
     result = evaluate_retrieval(eval_rows, retrieve_urls, top_k)
     print_evaluation(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arm-kb-search"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.10"
 dependencies = [
   "numpy",


### PR DESCRIPTION
## Summary
- Route retrieval evaluation through the shared `arm_kb_search.search()` path so eval matches production search behavior
- Set explicit search candidate depth from requested result count, avoiding accidental coupling to deduplication candidate count
- Add alternate expected URLs for eval questions where multiple relevant sources satisfy the query.
- Bump package version to `0.2.0`.