### PR TITLE
Update Github Actions versions and add eval acceptable source

### DIFF
--- a/.github/workflows/build-embeddings.yml
+++ b/.github/workflows/build-embeddings.yml
@@ -13,22 +13,22 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set build date (UTC)
         run: echo "BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push embeddings image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: embedding-generation
           file: embedding-generation/Dockerfile

--- a/.github/workflows/build-mcp-image.yml
+++ b/.github/workflows/build-mcp-image.yml
@@ -84,7 +84,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Build the exact upstream commit (head_sha) for workflow_run so the
           # images and manifests reference it. (The git tag is created later at
@@ -109,19 +109,19 @@ jobs:
           echo "date_tag=$DATE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         # Only publishing runs push, so only they log in. Non-dry implies main
         # (the top-level guard rejects non-main non-dry runs).
         if: ${{ env.IS_DRY_RUN != 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push ${{ matrix.platform }} image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: mcp-local/Dockerfile
@@ -151,7 +151,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Check out the upstream build's commit (head_sha) as the base; the
           # bump step opens a PR from this commit and the git tag is created at
@@ -160,12 +160,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         # Only publishing runs write to the registry (non-dry implies main).
         if: ${{ env.IS_DRY_RUN != 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/embedding-unit-tests.yml
+++ b/.github/workflows/embedding-unit-tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -31,7 +31,7 @@ jobs:
           pip install -r mcp-local/tests/requirements.txt
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build MCP Docker image
         run: |

--- a/embedding-generation/eval_questions.json
+++ b/embedding-generation/eval_questions.json
@@ -2585,7 +2585,8 @@
   {
     "question": "nginx performance tweaks",
     "expected_urls": [
-      "https://amperecomputing.com/tuning-guides/nginx-tuning-guide"
+      "https://amperecomputing.com/tuning-guides/nginx-tuning-guide",
+      "https://learn.arm.com/learning-paths/servers-and-cloud-computing/nginx_tune/"
     ]
   },
   {

--- a/embedding-generation/vector-db-sources.csv
+++ b/embedding-generation/vector-db-sources.csv
@@ -1778,7 +1778,7 @@ Workload Brief,,Object Storage MinIO Single Node,https://www.amperecomputing.com
 Workload Brief,,Redis on Azure Workload Brief - updated replacement,https://amperecomputing.com/briefs/redis-on-azure-brief,Ampere; Ampere Altra; Azure Dpsv5; Redis; P99 latency,
 Workload Brief,,Redis on Bare Metal Workload Brief,https://amperecomputing.com/briefs/redis-workload-brief,Ampere; Ampere Altra Max; Redis,
 Workload Brief,,Redis on Google Cloud Workload Brief,https://amperecomputing.com/briefs/redis-on-google-brief,Ampere; Ampere Altra; Tau T2A; Redis,
-Workload Brief,,Spark on OCI Workload Brief,https://amperecomputing.com/briefs/spark-on-OCI-brief,Ampere; Ampere A1; Ampere Altra; OCI; Apache Spark; TeraSort; TPC-DS; YARN,
+Workload Brief,,Spark on OCI Workload Brief,https://amperecomputing.com/briefs/spark-on-oci-brief,Ampere; Ampere A1; Ampere Altra; OCI; Apache Spark; TeraSort; TPC-DS; YARN,
 Workload Brief,,Spark on Google Cloud Brief,https://amperecomputing.com/briefs/spark-on-google-brief,Ampere; Ampere Altra; Google Cloud; Tau T2A; Apache Spark; TeraSort; YARN,
 Workload Brief,,Spark on Azure Brief,https://amperecomputing.com/briefs/spark-on-azure-brief,Ampere; Ampere Altra; Azure; Apache Spark; TeraSort; HiBench,
 Workload Brief,,Spark Workload Brief,https://amperecomputing.com/briefs/spark-workload-brief,Ampere; Ampere Altra; Apache Spark; TeraSort; TPC-DS; Intel Ice Lake,

--- a/mcp-local/tests/constants.py
+++ b/mcp-local/tests/constants.py
@@ -102,7 +102,8 @@ CHECK_NGINX_REQUEST = {
         }
 
 EXPECTED_CHECK_NGINX_RESPONSE = [
-    "https://amperecomputing.com/tuning-guides/nginx-tuning-guide"
+    "https://amperecomputing.com/tuning-guides/nginx-tuning-guide",
+    "https://learn.arm.com/learning-paths/servers-and-cloud-computing/nginx_tune",
     ]
 
 CHECK_MIGRATE_EASE_TOOL_REQUEST = {


### PR DESCRIPTION
This PR does two things:
- Updates Github Actions workflow versions to higher versions which use Node 24, since [Node 20 is now deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners). This was showing warnings on all of our workflows
- Adds an acceptable source to a currently failing eval question about nginx performance tweaks; also adding same source to integration test revolving around the same query
- Corrects an ampere source URL to new lowercase version