### PR TITLE
Pin numkong and usearch to fix build fail

### DIFF
--- a/embedding-generation/requirements.txt
+++ b/embedding-generation/requirements.txt
@@ -1,7 +1,8 @@
 requests
 beautifulsoup4
 pyyaml
-usearch
+usearch==2.26.0
+numkong==7.7.0
 boto3
 sentence-transformers>=5.4
 pypdf

--- a/mcp-local/Dockerfile
+++ b/mcp-local/Dockerfile
@@ -82,14 +82,10 @@ ENV VIRTUAL_ENV=/app/.venv \
 RUN python3 -m venv "$VIRTUAL_ENV" && pip install --upgrade pip
 
 COPY mcp-local/requirements.txt .
-# Install dependencies using CPU-only PyTorch wheels for supported Linux targets.
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] || [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-        PIP_INDEX_URL=https://download.pytorch.org/whl/cpu \
-        PIP_EXTRA_INDEX_URL=https://pypi.org/simple \
-        pip install --no-cache-dir -r requirements.txt; \
-    else \
-        pip install --no-cache-dir -r requirements.txt; \
-    fi
+# Install dependencies using CPU-only PyTorch wheels.
+RUN PIP_INDEX_URL=https://download.pytorch.org/whl/cpu \
+    PIP_EXTRA_INDEX_URL=https://pypi.org/simple \
+    pip install --only-binary=:all: --no-cache-dir -r requirements.txt
 
 RUN mkdir -p "$HF_HOME" "$SENTENCE_TRANSFORMERS_HOME" && \
     python -c "from sentence_transformers import SentenceTransformer; import os; SentenceTransformer(os.environ['SENTENCE_TRANSFORMER_MODEL'], cache_folder=os.environ['SENTENCE_TRANSFORMERS_HOME'])"

--- a/mcp-local/requirements.txt
+++ b/mcp-local/requirements.txt
@@ -1,5 +1,7 @@
 torch==2.10.0
-usearch
+usearch==2.26.0
+# USearch leaves NumKong unconstrained, so pin it explicitly for reproducible wheel installs.
+numkong==7.7.0
 pyyaml
 requests
 mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ dependencies = [
   "numpy",
   "rank-bm25",
   "sentence-transformers>=5.4",
-  "usearch",
+  "usearch==2.26.0",
+  "numkong==7.7.0",
 ]
 
 [build-system]


### PR DESCRIPTION
Fix integration builds broken by NumKong 7.7.1, which was published without compatible wheels.

- Pin usearch==2.26.0 and numkong==7.7.0.
- Require binary wheels to prevent unexpected source builds.
- Always use the CPU-only PyTorch index.