### PR TITLE
Add eval questions for developer.arm.com content

### DIFF
--- a/embedding-generation/eval_questions.json
+++ b/embedding-generation/eval_questions.json
@@ -2586,9 +2586,489 @@
     ]
   },
   {
-    "question": "devices that support SME and SME2",
+    "question": "Which phones, Macs, and iPads have native SME2 support?",
     "expected_urls": [
       "https://learn.arm.com/learning-paths/cross-platform/multiplying-matrices-with-sme2/1-get-started/#devices"
+    ]
+  },
+  {
+    "question": "Why would I use SME for matrix-heavy code?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109974/0100/Overview-of-SME?lang=en"
+    ]
+  },
+  {
+    "question": "Can you explain the difference between SME and SME2?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-and-SME2?lang=en"
+    ]
+  },
+  {
+    "question": "What do I need to know about saving and restoring SME state?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-context-save-restore?lang=en"
+    ]
+  },
+  {
+    "question": "How does ZA storage work in SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-ZA-storage?lang=en"
+    ]
+  },
+  {
+    "question": "How do I check if SME or SME2 is supported?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-and-SME2/If-SME-and-SME2-are-supported?lang=en"
+    ]
+  },
+  {
+    "question": "How do I build and run a simple SME application?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/How-to-run-an-SME-application?lang=en"
+    ]
+  },
+  {
+    "question": "Can you give me a quick explanation of SME and SME2?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109974/0100/What-is-SME-SME2-?lang=en"
+    ]
+  },
+  {
+    "question": "How does SME2 multi-vector predication work?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-and-SME2/SME2-multi-vector-predication?lang=en"
+    ]
+  },
+  {
+    "question": "How can I use SME multi-vector loads to load multiple Z registers more efficiently?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Memory-access/Use-multi-vector-SME-loads-for-better-efficiency?lang=en"
+    ]
+  },
+  {
+    "question": "How do SME2 lookup table instructions work?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-and-SME2/SME2-lookup-table?lang=en"
+    ]
+  },
+  {
+    "question": "How do SME2 multi-vector operands work?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME2-multi-vector-operands?lang=en"
+    ]
+  },
+  {
+    "question": "What is Streaming SVE mode and when would I use it?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/Streaming-SVE-mode?lang=en"
+    ]
+  },
+  {
+    "question": "Which compiler options, feature identifiers, or ACLE pragmas do I need for SME code?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/Compiler-support/Compiler-options-and-pragmas?lang=en"
+    ]
+  },
+  {
+    "question": "How do ZA tiles map to array vectors?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-ZA-storage/ZA-array-vector-access-and-ZA-tile-mapping?lang=en"
+    ]
+  },
+  {
+    "question": "Which Arm Compiler and Clang versions support SME and SME2 applications?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/Compiler-support?lang=en"
+    ]
+  },
+  {
+    "question": "What is the preprocess_r function?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-function-overview?lang=en"
+    ]
+  },
+  {
+    "question": "What tools can I use to debug SME code?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/Debug-tools?lang=en"
+    ]
+  },
+  {
+    "question": "How do I turn Streaming SVE mode on or off in code?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/Calling-conventions/Controlling-the-use-of-streaming-mode?lang=en"
+    ]
+  },
+  {
+    "question": "How should I handle Streaming SVE mode across function boundaries?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/Calling-conventions/Controlling-the-use-of-streaming-mode/Managing-streaming-mode-across-function-boundaries?lang=en"
+    ]
+  },
+  {
+    "question": "Can you show me a minimal SME assembly example?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109974/0100/Basic-SME-example/Assembly-code?lang=en"
+    ]
+  },
+  {
+    "question": "What is the preprocess_l function?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-function-overview?lang=en"
+    ]
+  },
+  {
+    "question": "What calling conventions do I need to follow when writing SME code?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/Calling-conventions?lang=en"
+    ]
+  },
+  {
+    "question": "What is the lut_gemv_opt function?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/lut-gemv-opt-function-overview?lang=en"
+    ]
+  },
+  {
+    "question": "How do I control ZA storage use across function calls?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/Calling-conventions/Controlling-the-use-of-ZA-storage?lang=en"
+    ]
+  },
+  {
+    "question": "How should I structure an optimized FP32 SME matrix multiplication kernel?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-function-overview?lang=en"
+    ]
+  },
+  {
+    "question": "How is Streaming SVE used in SME code?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109974/0100/Streaming-SVE?lang=en"
+    ]
+  },
+  {
+    "question": "What programmer model changes did SME add to Armv9-A for matrix workloads?",
+    "expected_urls": [
+      "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/scalable-matrix-extension-armv9-a-architecture"
+    ]
+  },
+  {
+    "question": "How do I write an FP32 matrix multiplication example with SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication?lang=en"
+    ]
+  },
+  {
+    "question": "How do I write an int8 matrix multiplication example with SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication?lang=en"
+    ]
+  },
+  {
+    "question": "How do I write an int8 lookup-table GEMV example with SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication?lang=en"
+    ]
+  },
+  {
+    "question": "How does an int8 matrix-vector multiply algorithm work with SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/Overview-of-the-gemv-cm-int8-algorithm?lang=en"
+    ]
+  },
+  {
+    "question": "How does an FP32 matrix multiplication algorithm work with SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/Overview-of-the-matmul-fp32-algorithm?lang=en"
+    ]
+  },
+  {
+    "question": "How does an int8 lookup-table GEMV algorithm work with SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/Overview-of-the-lut-gemv-rm-int8-algorithm?lang=en"
+    ]
+  },
+  {
+    "question": "How should I structure an optimized int8 SME matrix multiplication kernel?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/matmul-opt-function-overview?lang=en"
+    ]
+  },
+  {
+    "question": "Can you give me a beginner-friendly introduction to Arm SME?",
+    "expected_urls": [
+      "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/arm-scalable-matrix-extension-introduction"
+    ]
+  },
+  {
+    "question": "What should my code do before entering or leaving Streaming SVE mode?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/Calling-conventions/Preparation-for-entering-and-exiting-streaming-mode?lang=en"
+    ]
+  },
+  {
+    "question": "Which SME load and store instructions should I use?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109974/0100/Introduction-to-SME-instructions/Load-and-Store?lang=en"
+    ]
+  },
+  {
+    "question": "How does the int8 matrix multiplication algorithm work with SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/Overview-of-the-matmul-int8-algorithm?lang=en"
+    ]
+  },
+  {
+    "question": "Which SME ZA tile instructions should I learn after the basics?",
+    "expected_urls": [
+      "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/arm-scalable-matrix-extension-introduction-p2"
+    ]
+  },
+  {
+    "question": "Where should I start if I want to learn SME programming?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Introduction?lang=en"
+    ]
+  },
+  {
+    "question": "How do SME2 multi-vector and lookup-table features extend SME?",
+    "expected_urls": [
+      "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/part4-arm-sme2-introduction"
+    ]
+  },
+  {
+    "question": "How should I optimize an int8 GEMV kernel with SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-function-overview?lang=en"
+    ]
+  },
+  {
+    "question": "How would I port matrix multiplication from Neon or SVE to SME?",
+    "expected_urls": [
+      "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/matrix-matrix-multiplication-neon-sve-and-sme-compared"
+    ]
+  },
+  {
+    "question": "How do I implement left-hand preprocessing for FP32 SME matmul?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/preprocess-l-code?lang=en"
+    ]
+  },
+  {
+    "question": "How do I implement right-hand preprocessing for int8 SME matmul?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-code?lang=en"
+    ]
+  },
+  {
+    "question": "Why does FP32 SME matmul need a left-hand preprocessing step?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/preprocess-l-function-overview?lang=en"
+    ]
+  },
+  {
+    "question": "How do Streaming SVE mode and ZA storage fit together in SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Introduction/The-Scalable-Matrix-Extensions/Streaming-SVE-mode-and-ZA-storage?lang=en"
+    ]
+  },
+  {
+    "question": "How do I implement left-hand preprocessing for int8 SME matmul?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-code?lang=en"
+    ]
+  },
+  {
+    "question": "How does CME handle address translation and memory access without its own MMU?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Memory-access?lang=en"
+    ]
+  },
+  {
+    "question": "How do Z registers relate to ZA storage in SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109974/0100/ZA-storage/Z-registers?lang=en"
+    ]
+  },
+  {
+    "question": "Can you show an optimized int8 SME matrix multiplication loop?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/matmul-opt-code?lang=en"
+    ]
+  },
+  {
+    "question": "Can you show an optimized FP32 SME matrix multiplication loop?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-code?lang=en"
+    ]
+  },
+  {
+    "question": "What should I watch out for when writing int8 right-hand preprocessing for SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-function-details?lang=en"
+    ]
+  },
+  {
+    "question": "Why are matrices used in real applications?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109974/0100/Why-are-matrices-used-/Real-world-examples?lang=en"
+    ]
+  },
+  {
+    "question": "What is CME and why would my code care about it?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Introduction-to-CME?lang=en"
+    ]
+  },
+  {
+    "question": "How do different CME system configurations affect my code?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/CME-system-configurations/Implications-for-programmers?lang=en"
+    ]
+  },
+  {
+    "question": "What should I watch out for when writing int8 left-hand preprocessing for SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-function-details?lang=en"
+    ]
+  },
+  {
+    "question": "What should I watch out for when optimizing an int8 lookup-table GEMV kernel?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/lut-gemv-opt-function-details?lang=en"
+    ]
+  },
+  {
+    "question": "How can I avoid memory access conflicts between CPU instructions and SME instructions on the CME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Memory-access/Avoid-access-conflicts-in-1KB-regions?lang=en"
+    ]
+  },
+  {
+    "question": "Should I use PMU events or SPE samples to monitor CME performance?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Performance-monitoring?lang=en"
+    ]
+  },
+  {
+    "question": "Which CME pipeline components matter when I am optimizing SME code?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Introduction-to-CME/CME-components?lang=en"
+    ]
+  },
+  {
+    "question": "Which CME activity can I track with PMU events?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Performance-monitoring/CME-and-the-PMU?lang=en"
+    ]
+  },
+  {
+    "question": "Can you show the optimized code for an int8 lookup-table GEMV kernel?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/lut-gemv-opt-code?lang=en"
+    ]
+  },
+  {
+    "question": "Can you show the optimized code for an int8 GEMV kernel?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-code?lang=en"
+    ]
+  },
+  {
+    "question": "How should I think about ZA storage when writing SME code?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109974/0100/ZA-storage?lang=en"
+    ]
+  },
+  {
+    "question": "What should I watch out for when optimizing an FP32 SME matmul kernel?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-function-details?lang=en"
+    ]
+  },
+  {
+    "question": "What should I watch out for when writing FP32 left-hand preprocessing for SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/preprocess-l-function-details?lang=en"
+    ]
+  },
+  {
+    "question": "What should I watch out for when optimizing an int8 GEMV kernel?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-function-details?lang=en"
+    ]
+  },
+  {
+    "question": "Can I use SPE to understand CME performance?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Performance-monitoring/CME-and-the-SPE?lang=en"
+    ]
+  },
+  {
+    "question": "How can I avoid CPU-CME synchronization overhead in loops?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/CME-instruction-execution/Implications-for-programmers?lang=en"
+    ]
+  },
+  {
+    "question": "Why does an operating system use Fast Context Switching Instructions with CME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/CME-system-configurations/Fast-Context-Switching-Instructions?lang=en"
+    ]
+  },
+  {
+    "question": "How do single-CME and multi-CME configurations affect arbitration?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/CME-system-configurations?lang=en"
+    ]
+  },
+  {
+    "question": "Can you show me a CME loop that avoids synchronization back to the CPU?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/CME-instruction-execution/Example-1--efficient-loop?lang=en"
+    ]
+  },
+  {
+    "question": "How does predication work in SME?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109974/0100/Predication?lang=en"
+    ]
+  },
+  {
+    "question": "Why do predicate or flag updates make a CME loop inefficient?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/CME-instruction-execution/Example-2--inefficient-loop?lang=en"
+    ]
+  },
+  {
+    "question": "How do I avoid Matrix Multiply Unit stalls from reusing the same ZA tile?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Matrix-Multiply-Unit/Implications-for-programmers?lang=en"
+    ]
+  },
+  {
+    "question": "Which SME outer-product operations use the CME Matrix Multiply Unit?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Matrix-Multiply-Unit?lang=en"
+    ]
+  },
+  {
+    "question": "Which instructions run on the CPU versus the CME, and when is synchronization required?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/CME-instruction-execution?lang=en"
+    ]
+  },
+  {
+    "question": "How does the CME Assignment Block choose a CME in a multi-CME system?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/CME-system-configurations/Multi-CME-systems?lang=en"
+    ]
+  },
+  {
+    "question": "How do priorities, fair-share arbitration, and exclusive arbitration work on a single-CME system?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/CME-system-configurations/Single-CME-systems?lang=en"
     ]
   }
 ]

--- a/embedding-generation/eval_questions.json
+++ b/embedding-generation/eval_questions.json
@@ -2586,7 +2586,7 @@
     ]
   },
   {
-    "question": "Which phones, Macs, and iPads have native SME2 support?",
+    "question": "devices that support SME and SME2",
     "expected_urls": [
       "https://learn.arm.com/learning-paths/cross-platform/multiplying-matrices-with-sme2/1-get-started/#devices"
     ]

--- a/embedding-generation/eval_questions.json
+++ b/embedding-generation/eval_questions.json
@@ -2748,7 +2748,7 @@
     ]
   },
   {
-    "question": "What programmer model changes did SME add to Armv9-A for matrix workloads?",
+    "question": "What changes did SME add to Armv9-A?",
     "expected_urls": [
       "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/scalable-matrix-extension-armv9-a-architecture"
     ]
@@ -2766,7 +2766,7 @@
     ]
   },
   {
-    "question": "How do I write an int8 lookup-table GEMV example with SME?",
+    "question": "How can I do int8 matrix-by-vector multiplication with SME?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication?lang=en"
     ]
@@ -2790,7 +2790,7 @@
     ]
   },
   {
-    "question": "How should I structure an optimized int8 SME matrix multiplication kernel?",
+    "question": "How can I optimize int8 matrix-by-matrix multiplication with SME?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/matmul-opt-function-overview?lang=en"
     ]
@@ -2820,7 +2820,7 @@
     ]
   },
   {
-    "question": "Which SME ZA tile instructions should I learn after the basics?",
+    "question": "Which SME ZA tile instructions should I learn?",
     "expected_urls": [
       "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/arm-scalable-matrix-extension-introduction-p2"
     ]
@@ -2904,7 +2904,7 @@
     ]
   },
   {
-    "question": "What should I watch out for when writing int8 right-hand preprocessing for SME?",
+    "question": "Can you give me the details for int8 right-hand preprocessing in SME?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-function-details?lang=en"
     ]
@@ -2916,7 +2916,7 @@
     ]
   },
   {
-    "question": "What is CME and why would my code care about it?",
+    "question": "Can you give me an intro to CME?",
     "expected_urls": [
       "https://developer.arm.com/documentation/110636/0100/Introduction-to-CME?lang=en"
     ]
@@ -2928,13 +2928,13 @@
     ]
   },
   {
-    "question": "What should I watch out for when writing int8 left-hand preprocessing for SME?",
+    "question": "Can you give me the details for writing int8 left-hand preprocessing for SME?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-function-details?lang=en"
     ]
   },
   {
-    "question": "What should I watch out for when optimizing an int8 lookup-table GEMV kernel?",
+    "question": "Can you give me the details for optimizing an int8 lookup-table GEMV kernel?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/lut-gemv-opt-function-details?lang=en"
     ]
@@ -2982,19 +2982,19 @@
     ]
   },
   {
-    "question": "What should I watch out for when optimizing an FP32 SME matmul kernel?",
+    "question": "Can you give me the details for optimizing an FP32 SME matmul kernel?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-function-details?lang=en"
     ]
   },
   {
-    "question": "What should I watch out for when writing FP32 left-hand preprocessing for SME?",
+    "question": "Can you give me the details for writing FP32 left-hand preprocessing for SME?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/preprocess-l-function-details?lang=en"
     ]
   },
   {
-    "question": "What should I watch out for when optimizing an int8 GEMV kernel?",
+    "question": "Can you give me the details for optimizing an int8 GEMV kernel?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-function-details?lang=en"
     ]
@@ -3018,7 +3018,7 @@
     ]
   },
   {
-    "question": "How do single-CME and multi-CME configurations affect arbitration?",
+    "question": "Can you tell me about CME system configurations?",
     "expected_urls": [
       "https://developer.arm.com/documentation/110636/0100/CME-system-configurations?lang=en"
     ]
@@ -3060,13 +3060,13 @@
     ]
   },
   {
-    "question": "How does the CME Assignment Block choose a CME in a multi-CME system?",
+    "question": "Can you tell me more about multi-CME system?",
     "expected_urls": [
       "https://developer.arm.com/documentation/110636/0100/CME-system-configurations/Multi-CME-systems?lang=en"
     ]
   },
   {
-    "question": "How do priorities, fair-share arbitration, and exclusive arbitration work on a single-CME system?",
+    "question": "Can you tell me about CME system configurations?",
     "expected_urls": [
       "https://developer.arm.com/documentation/110636/0100/CME-system-configurations/Single-CME-systems?lang=en"
     ]

--- a/embedding-generation/eval_questions.json
+++ b/embedding-generation/eval_questions.json
@@ -2605,6 +2605,12 @@
     ]
   },
   {
+    "question": "How do SVE, SVE2, and SME extend the Armv9-A architecture for vector and matrix processing?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/Introduction?lang=en"
+    ]
+  },
+  {
     "question": "How does SME context save and restore preserve Streaming SVE mode and ZA storage state?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-context-save-restore?lang=en"
@@ -2623,7 +2629,7 @@
     ]
   },
   {
-    "question": "How do I compile and run the SME Programmer's Guide example application?",
+    "question": "How can I compile and run an application that uses SME on Arm?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/How-to-run-an-SME-application?lang=en"
     ]
@@ -2756,15 +2762,21 @@
     ]
   },
   {
-    "question": "How does the matmul-fp32 single-precision SME matrix-by-matrix multiplication example work?",
+    "question": "How can I implement FP32 matrix multiplication with SME2?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/Overview-of-the-matmul-fp32-algorithm?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-code?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-function-details?lang=en"
     ]
   },
   {
-    "question": "How does the matmul-int8 8-bit to 32-bit SME matrix-by-matrix multiplication example work?",
+    "question": "How can I use SME2 to multiply 8-bit integer matrices and produce 32-bit results?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/Overview-of-the-matmul-int8-algorithm?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/matmul-opt-function-overview?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/matmul-opt-code?lang=en"
     ]
   },
   {
@@ -2780,21 +2792,10 @@
     ]
   },
   {
-    "question": "What is the matmul-fp32 algorithm for single-precision SME matrix-by-matrix multiplication?",
+    "question": "How can I use SME2 for matrix-vector multiplication with compressed int8 data?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/Overview-of-the-matmul-fp32-algorithm?lang=en"
-    ]
-  },
-  {
-    "question": "How does an int8 lookup-table GEMV algorithm work with SME?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/Overview-of-the-lut-gemv-rm-int8-algorithm?lang=en"
-    ]
-  },
-  {
-    "question": "What does the matmul_opt function do in the int8-to-int32 SME matrix-by-matrix multiplication example?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/matmul-opt-function-overview?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/Overview-of-the-lut-gemv-rm-int8-algorithm?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/lut-gemv-opt-code?lang=en"
     ]
   },
   {
@@ -2816,22 +2817,9 @@
     ]
   },
   {
-    "question": "What is the matmul-int8 algorithm for 8-bit to 32-bit SME matrix-by-matrix multiplication?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/Overview-of-the-matmul-int8-algorithm?lang=en"
-    ]
-  },
-  {
     "question": "Which SME ZA tile instructions should I learn?",
     "expected_urls": [
       "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/arm-scalable-matrix-extension-introduction-p2"
-    ]
-  },
-  {
-    "question": "What does the SME Programmer's Guide introduction explain about SME and SME2?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/Introduction?lang=en",
-      "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-and-SME2?lang=en"
     ]
   },
   {
@@ -2841,9 +2829,11 @@
     ]
   },
   {
-    "question": "What does the gemv_opt function do in the int8-to-int32 column-major SME matrix-by-vector example?",
+    "question": "How can I optimize column-major 8-bit integer matrix-vector multiplication with SME2?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-function-overview?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-function-overview?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-code?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-function-details?lang=en"
     ]
   },
   {
@@ -2897,26 +2887,13 @@
     ]
   },
   {
-    "question": "What is the matmul_opt code for int8-to-int32 SME matrix-by-matrix multiplication?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/matmul-opt-code?lang=en",
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication?lang=en"
-    ]
-  },
-  {
-    "question": "What is the matmul_opt code for FP32 SME matrix-by-matrix multiplication?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-code?lang=en"
-    ]
-  },
-  {
     "question": "What are the preprocess_r function details for int8-to-int32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-function-details?lang=en"
     ]
   },
   {
-    "question": "Why are matrices used in real applications?",
+    "question": "How are matrices used in real applications?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109974/0100/Why-are-matrices-used-/Real-world-examples?lang=en"
     ]
@@ -2971,39 +2948,15 @@
     ]
   },
   {
-    "question": "What is the lut_gemv_opt code for compressed int8 lookup-table SME matrix-by-vector multiplication?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/lut-gemv-opt-code?lang=en"
-    ]
-  },
-  {
-    "question": "What is the gemv_opt code for int8-to-int32 column-major SME matrix-by-vector multiplication?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-code?lang=en"
-    ]
-  },
-  {
     "question": "How should I think about ZA storage when writing SME code?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109974/0100/ZA-storage?lang=en"
     ]
   },
   {
-    "question": "What are the matmul_opt function details for FP32 SME matrix-by-matrix multiplication?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-function-details?lang=en"
-    ]
-  },
-  {
     "question": "What are the preprocess_l function details for FP32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/preprocess-l-function-details?lang=en"
-    ]
-  },
-  {
-    "question": "What are the gemv_opt function details for int8-to-int32 column-major SME matrix-by-vector multiplication?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-function-details?lang=en"
     ]
   },
   {

--- a/embedding-generation/eval_questions.json
+++ b/embedding-generation/eval_questions.json
@@ -2592,8 +2592,9 @@
     ]
   },
   {
-    "question": "Why would I use SME for matrix-heavy code?",
+    "question": "What is Arm SME, the Scalable Matrix Extension introduced for matrix processing?",
     "expected_urls": [
+      "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/arm-scalable-matrix-extension-introduction",
       "https://developer.arm.com/documentation/109974/0100/Overview-of-SME?lang=en"
     ]
   },
@@ -2604,7 +2605,7 @@
     ]
   },
   {
-    "question": "What do I need to know about saving and restoring SME state?",
+    "question": "How does SME context save and restore preserve Streaming SVE mode and ZA storage state?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-context-save-restore?lang=en"
     ]
@@ -2622,7 +2623,7 @@
     ]
   },
   {
-    "question": "How do I build and run a simple SME application?",
+    "question": "How do I compile and run the SME Programmer's Guide example application?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/How-to-run-an-SME-application?lang=en"
     ]
@@ -2694,8 +2695,9 @@
     ]
   },
   {
-    "question": "How do I turn Streaming SVE mode on or off in code?",
+    "question": "How do I control Streaming SVE mode with SMSTART and SMSTOP in SME code?",
     "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/Streaming-SVE-mode?lang=en",
       "https://developer.arm.com/documentation/109246/0101/Toolchains-and-model-support/Calling-conventions/Controlling-the-use-of-streaming-mode?lang=en"
     ]
   },
@@ -2736,7 +2738,7 @@
     ]
   },
   {
-    "question": "How should I structure an optimized FP32 SME matrix multiplication kernel?",
+    "question": "What does the matmul_opt function do in the FP32 SME matrix-by-matrix multiplication example?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-function-overview?lang=en"
     ]
@@ -2754,13 +2756,13 @@
     ]
   },
   {
-    "question": "How do I write an FP32 matrix multiplication example with SME?",
+    "question": "How does the matmul-fp32 single-precision SME matrix-by-matrix multiplication example work?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication?lang=en"
     ]
   },
   {
-    "question": "How do I write an int8 matrix multiplication example with SME?",
+    "question": "How does the matmul-int8 8-bit to 32-bit SME matrix-by-matrix multiplication example work?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication?lang=en"
     ]
@@ -2778,7 +2780,7 @@
     ]
   },
   {
-    "question": "How does an FP32 matrix multiplication algorithm work with SME?",
+    "question": "What is the matmul-fp32 algorithm for single-precision SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/Overview-of-the-matmul-fp32-algorithm?lang=en"
     ]
@@ -2790,7 +2792,7 @@
     ]
   },
   {
-    "question": "How can I optimize int8 matrix-by-matrix multiplication with SME?",
+    "question": "What does the matmul_opt function do in the int8-to-int32 SME matrix-by-matrix multiplication example?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/matmul-opt-function-overview?lang=en"
     ]
@@ -2814,7 +2816,7 @@
     ]
   },
   {
-    "question": "How does the int8 matrix multiplication algorithm work with SME?",
+    "question": "What is the matmul-int8 algorithm for 8-bit to 32-bit SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/Overview-of-the-matmul-int8-algorithm?lang=en"
     ]
@@ -2826,9 +2828,10 @@
     ]
   },
   {
-    "question": "Where should I start if I want to learn SME programming?",
+    "question": "What does the SME Programmer's Guide introduction explain about SME and SME2?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/Introduction?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/Introduction?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/SME-Overview/SME-and-SME2?lang=en"
     ]
   },
   {
@@ -2838,7 +2841,7 @@
     ]
   },
   {
-    "question": "How should I optimize an int8 GEMV kernel with SME?",
+    "question": "What does the gemv_opt function do in the int8-to-int32 column-major SME matrix-by-vector example?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-function-overview?lang=en"
     ]
@@ -2850,19 +2853,20 @@
     ]
   },
   {
-    "question": "How do I implement left-hand preprocessing for FP32 SME matmul?",
+    "question": "What is the preprocess_l code for FP32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/preprocess-l-code?lang=en"
     ]
   },
   {
-    "question": "How do I implement right-hand preprocessing for int8 SME matmul?",
+    "question": "What is the preprocess_r code for int8-to-int32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-code?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-code?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication?lang=en"
     ]
   },
   {
-    "question": "Why does FP32 SME matmul need a left-hand preprocessing step?",
+    "question": "What does the preprocess_l function do for FP32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/preprocess-l-function-overview?lang=en"
     ]
@@ -2874,13 +2878,14 @@
     ]
   },
   {
-    "question": "How do I implement left-hand preprocessing for int8 SME matmul?",
+    "question": "What is the preprocess_l code for int8-to-int32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-code?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-code?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication?lang=en"
     ]
   },
   {
-    "question": "How does CME handle address translation and memory access without its own MMU?",
+    "question": "What memory access capabilities does CME provide?",
     "expected_urls": [
       "https://developer.arm.com/documentation/110636/0100/Memory-access?lang=en"
     ]
@@ -2892,19 +2897,20 @@
     ]
   },
   {
-    "question": "Can you show an optimized int8 SME matrix multiplication loop?",
+    "question": "What is the matmul_opt code for int8-to-int32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/matmul-opt-code?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/matmul-opt-code?lang=en",
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication?lang=en"
     ]
   },
   {
-    "question": "Can you show an optimized FP32 SME matrix multiplication loop?",
+    "question": "What is the matmul_opt code for FP32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-code?lang=en"
     ]
   },
   {
-    "question": "Can you give me the details for int8 right-hand preprocessing in SME?",
+    "question": "What are the preprocess_r function details for int8-to-int32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-function-details?lang=en"
     ]
@@ -2922,19 +2928,19 @@
     ]
   },
   {
-    "question": "How do different CME system configurations affect my code?",
+    "question": "What are the programming implications of different CME system configurations?",
     "expected_urls": [
       "https://developer.arm.com/documentation/110636/0100/CME-system-configurations/Implications-for-programmers?lang=en"
     ]
   },
   {
-    "question": "Can you give me the details for writing int8 left-hand preprocessing for SME?",
+    "question": "What are the preprocess_l function details for int8-to-int32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-function-details?lang=en"
     ]
   },
   {
-    "question": "Can you give me the details for optimizing an int8 lookup-table GEMV kernel?",
+    "question": "What are the lut_gemv_opt function details for compressed int8 lookup-table SME matrix-by-vector multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/lut-gemv-opt-function-details?lang=en"
     ]
@@ -2946,8 +2952,9 @@
     ]
   },
   {
-    "question": "Should I use PMU events or SPE samples to monitor CME performance?",
+    "question": "How do CME performance monitoring, PMU events, and SPE sampling work?",
     "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/Performance-monitoring/CME-and-the-PMU?lang=en",
       "https://developer.arm.com/documentation/110636/0100/Performance-monitoring?lang=en"
     ]
   },
@@ -2964,13 +2971,13 @@
     ]
   },
   {
-    "question": "Can you show the optimized code for an int8 lookup-table GEMV kernel?",
+    "question": "What is the lut_gemv_opt code for compressed int8 lookup-table SME matrix-by-vector multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/lut-gemv-opt-code?lang=en"
     ]
   },
   {
-    "question": "Can you show the optimized code for an int8 GEMV kernel?",
+    "question": "What is the gemv_opt code for int8-to-int32 column-major SME matrix-by-vector multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-code?lang=en"
     ]
@@ -2982,19 +2989,19 @@
     ]
   },
   {
-    "question": "Can you give me the details for optimizing an FP32 SME matmul kernel?",
+    "question": "What are the matmul_opt function details for FP32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-function-details?lang=en"
     ]
   },
   {
-    "question": "Can you give me the details for writing FP32 left-hand preprocessing for SME?",
+    "question": "What are the preprocess_l function details for FP32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/preprocess-l-function-details?lang=en"
     ]
   },
   {
-    "question": "Can you give me the details for optimizing an int8 GEMV kernel?",
+    "question": "What are the gemv_opt function details for int8-to-int32 column-major SME matrix-by-vector multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-function-details?lang=en"
     ]
@@ -3006,7 +3013,7 @@
     ]
   },
   {
-    "question": "How can I avoid CPU-CME synchronization overhead in loops?",
+    "question": "What are the programming implications of CME instruction execution and CPU-CME synchronization in loops?",
     "expected_urls": [
       "https://developer.arm.com/documentation/110636/0100/CME-instruction-execution/Implications-for-programmers?lang=en"
     ]
@@ -3018,8 +3025,9 @@
     ]
   },
   {
-    "question": "Can you tell me about CME system configurations?",
+    "question": "How do CME system configurations, including single-CME systems, work?",
     "expected_urls": [
+      "https://developer.arm.com/documentation/110636/0100/CME-system-configurations/Single-CME-systems?lang=en",
       "https://developer.arm.com/documentation/110636/0100/CME-system-configurations?lang=en"
     ]
   },
@@ -3063,12 +3071,6 @@
     "question": "Can you tell me more about multi-CME system?",
     "expected_urls": [
       "https://developer.arm.com/documentation/110636/0100/CME-system-configurations/Multi-CME-systems?lang=en"
-    ]
-  },
-  {
-    "question": "Can you tell me about CME system configurations?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/110636/0100/CME-system-configurations/Single-CME-systems?lang=en"
     ]
   }
 ]

--- a/embedding-generation/eval_questions.json
+++ b/embedding-generation/eval_questions.json
@@ -2607,7 +2607,8 @@
   {
     "question": "How do SVE, SVE2, and SME extend the Armv9-A architecture for vector and matrix processing?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/Introduction?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/Introduction?lang=en",
+      "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/scalable-matrix-extension-armv9-a-architecture"
     ]
   },
   {
@@ -2767,7 +2768,8 @@
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication?lang=en",
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/Overview-of-the-matmul-fp32-algorithm?lang=en",
       "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-code?lang=en",
-      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-function-details?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/matmul-opt-function-details?lang=en",
+      "https://learn.arm.com/learning-paths/cross-platform/multiplying-matrices-with-sme2/"
     ]
   },
   {
@@ -2792,7 +2794,7 @@
     ]
   },
   {
-    "question": "How can I use SME2 for matrix-vector multiplication with compressed int8 data?",
+    "question": "What does the lut_gemv_opt function do for SME2 compressed int8 matrix-vector multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/Overview-of-the-lut-gemv-rm-int8-algorithm?lang=en",
       "https://developer.arm.com/documentation/109246/0101/lut-gemv-rm-int8--Compressed-8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/lut-gemv-opt-code?lang=en"
@@ -2825,11 +2827,12 @@
   {
     "question": "How do SME2 multi-vector and lookup-table features extend SME?",
     "expected_urls": [
-      "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/part4-arm-sme2-introduction"
+      "https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/part4-arm-sme2-introduction",
+      "https://learn.arm.com/learning-paths/cross-platform/multiplying-matrices-with-sme2/overview/"
     ]
   },
   {
-    "question": "How can I optimize column-major 8-bit integer matrix-vector multiplication with SME2?",
+    "question": "What does the gemv_opt function do for SME2 column-major int8 matrix-vector multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-function-overview?lang=en",
       "https://developer.arm.com/documentation/109246/0101/gemv-cm-int8--8-bit-integer-to-32-bit-integer-matrix-by-vector-multiplication/gemv-opt-code?lang=en",

--- a/embedding-generation/eval_questions.json
+++ b/embedding-generation/eval_questions.json
@@ -2690,7 +2690,7 @@
     ]
   },
   {
-    "question": "What is the preprocess_r function?",
+    "question": "What is the preprocess_r function for int8-to-int32 matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-function-overview?lang=en"
     ]
@@ -2721,9 +2721,15 @@
     ]
   },
   {
-    "question": "What is the preprocess_l function?",
+    "question": "What is the preprocess_l function for int8-to-int32 matrix multiplication?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-function-overview?lang=en"
+    ]
+  },
+  {
+    "question": "What is the preprocess_l function for FP32 matrix multiplication?",
+    "expected_urls": [
+      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/preprocess-l-function-overview?lang=en"
     ]
   },
   {
@@ -2854,14 +2860,7 @@
   {
     "question": "What is the preprocess_r code for int8-to-int32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-code?lang=en",
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication?lang=en"
-    ]
-  },
-  {
-    "question": "What does the preprocess_l function do for FP32 SME matrix-by-matrix multiplication?",
-    "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-fp32--Single-precision-matrix-by-matrix-multiplication/preprocess-l-function-overview?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-code?lang=en"
     ]
   },
   {
@@ -2873,8 +2872,7 @@
   {
     "question": "What is the preprocess_l code for int8-to-int32 SME matrix-by-matrix multiplication?",
     "expected_urls": [
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-code?lang=en",
-      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication?lang=en"
+      "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-code?lang=en"
     ]
   },
   {

--- a/embedding-generation/eval_questions.json
+++ b/embedding-generation/eval_questions.json
@@ -2858,7 +2858,7 @@
     ]
   },
   {
-    "question": "What is the preprocess_r code for int8-to-int32 SME matrix-by-matrix multiplication?",
+    "question": "Where can I find the int8 preprocess_r code?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-r-code?lang=en"
     ]
@@ -2870,7 +2870,7 @@
     ]
   },
   {
-    "question": "What is the preprocess_l code for int8-to-int32 SME matrix-by-matrix multiplication?",
+    "question": "Where can I find the int8 preprocess_l code?",
     "expected_urls": [
       "https://developer.arm.com/documentation/109246/0101/matmul-int8--8-bit-integer-to-32-bit-integer-matrix-by-matrix-multiplication/preprocess-l-code?lang=en"
     ]


### PR DESCRIPTION
## Summary
- add retrieval evaluation questions for newly indexed SME, SME2, and CME documentation
- make preprocess_l and preprocess_r questions explicit for FP32 and int8 content
- use production-tested queries for the int8 preprocessing code pages

## Validation
- JSON validation passes
- production retrieval evaluation confirmed both revised int8 preprocess_l and preprocess_r code queries return their expected URLs in the top 5