### PR TITLE
Remove invocation-reasons.yaml

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,6 +5,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  unit-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install unit test dependencies
+        run: python -m pip install pytest
+
+      - name: Run unit tests
+        run: python -m pytest -q mcp-local/tests/test_invocation_logger.py
+
   integration-tests:
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# MCP server logs
+mcp-traffic.jsonl
+error_logging.yaml
 invocation_reasons.yaml
 
 # Virtual environments
@@ -37,4 +40,3 @@ embedding-generation/intrinsic_chunks/*.yaml
 embedding-generation/*.txt
 embedding-generation/metadata.json
 embedding-generation/usearch_index.bin
-

--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ args = [
 
 After updating the configuration, restart your MCP client to load the Arm MCP server.
 
+## Logging
+
+By default, the server creates two log files in `/workspace`. With the
+configuration examples above, these files appear in the project directory on
+your computer:
+
+- `mcp-traffic.jsonl` records when tools are used, the inputs provided, and the
+  reason for each tool call. It also records results from knowledge base
+  searches.
+- `error_logging.yaml` records details about errors encountered by the server.
+  This information can help with troubleshooting.
+
+These logs may contain information from your project and tool requests. Review
+their contents before sharing them.
+
 ## Repository Structure
 
 - **`mcp-local/`**: The MCP server implementation

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ After updating the configuration, restart your MCP client to load the Arm MCP se
 
 ## Logging
 
-By default, the server creates two log files in `/workspace`. With the
+Depending on usage, the server may write two log files under `/workspace`. With the
 configuration examples above, these files appear in the project directory on
 your computer:
 

--- a/mcp-local/server.py
+++ b/mcp-local/server.py
@@ -51,7 +51,7 @@ SEARCH_RESOURCES = arm_kb_search.load_search_resources(
     description="If a user asks to migrate a codebase to Arm, strongly consider using this tool as a part of your strategy. Searches an Arm knowledge base of learning resources, Arm intrinsics, and software version compatibility using semantic similarity. Given a natural language query, returns a list of matching resources with URLs, titles, and content snippets, ranked by relevance. Useful for finding documentation, tutorials, or version compatibility for Arm migrations. Returned URLs may include tracking query parameters such as utm_source=arm-mcp and URL fragments. When sharing or citing returned URLs, preserve each URL exactly as returned, including query parameters and fragments; do not remove, normalize, shorten, or rewrite them. Includes 'invocation_reason' parameter so the model can briefly explain why it is calling this tool to provide additional context."
 )
 def knowledge_base_search(query: str, invocation_reason: Optional[str] = None) -> List[Dict[str, Any]]:
-    # Log invocation reason if provided
+    # Log the call and retain its ID for the paired search result.
     entry_id = log_invocation_reason(
         tool="knowledge_base_search",
         reason=invocation_reason,

--- a/mcp-local/tests/constants.py
+++ b/mcp-local/tests/constants.py
@@ -131,7 +131,7 @@ EXPECTED_CHECK_MIGRATE_EASE_TOOL_RESPONSE = {
   "output_file": "/tmp/migrate_ease_java_20260126-215207.json",
   "output_format": "json",
   "workspace_listing": [
-    "invocation_reasons.yaml"
+    "mcp-traffic.jsonl"
   ],
   "excluded_items": [],
   "excluded_count": 0,

--- a/mcp-local/tests/test_invocation_logger.py
+++ b/mcp-local/tests/test_invocation_logger.py
@@ -1,12 +1,14 @@
 import json
+import sys
+from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from utils import invocation_logger
 
 
 def test_logs_paired_call_and_result(tmp_path, monkeypatch):
     traffic_path = tmp_path / "mcp-traffic.jsonl"
     monkeypatch.setattr(invocation_logger, "WORKSPACE_DIR", str(tmp_path))
-    monkeypatch.setenv(invocation_logger.MCP_TRAFFIC_LOG_ENV, str(traffic_path))
 
     entry_id = invocation_logger.log_invocation_reason(
         tool="knowledge_base_search",
@@ -37,7 +39,6 @@ def test_logs_paired_call_and_result(tmp_path, monkeypatch):
 def test_logs_call_without_invocation_reason(tmp_path, monkeypatch):
     traffic_path = tmp_path / "mcp-traffic.jsonl"
     monkeypatch.setattr(invocation_logger, "WORKSPACE_DIR", str(tmp_path))
-    monkeypatch.setenv(invocation_logger.MCP_TRAFFIC_LOG_ENV, str(traffic_path))
 
     entry_id = invocation_logger.log_invocation_reason(
         tool="knowledge_base_search",
@@ -48,4 +49,3 @@ def test_logs_call_without_invocation_reason(tmp_path, monkeypatch):
     entry = json.loads(traffic_path.read_text())
     assert entry["id"] == entry_id
     assert entry["invocation_reason"] is None
-    assert not (tmp_path / invocation_logger.LOG_FILE_NAME).exists()

--- a/mcp-local/utils/error_handling.py
+++ b/mcp-local/utils/error_handling.py
@@ -70,6 +70,6 @@ def format_tool_error(tool: str, exc: Exception, args: Optional[Dict[str, Any]] 
         "traceback": traceback.format_exc(),
         "args": args or {},
         "guidance": (
-            "Use this information to suggest fixes to the user. Also add that if the user is experiencing problems that are due to the MCP server itself, they can email mcpserver@arm.com. There is a file called invocation_reasons.yaml located in the /workspace container filesystem mount that records why the model decided to invoke a particular tool, and a file called error_logging.yaml that records recent errors. The user can also send these files to mcpserver@arm.com for added helpful troubleshooting context."
+            "Use this information to suggest fixes to the user. Also add that if the user is experiencing problems that are due to the MCP server itself, they can email mcpserver@arm.com. There is a file called mcp-traffic.jsonl located in the /workspace container filesystem mount that records tool calls and selected tool results, and a file called error_logging.yaml that records recent errors. The user can also send these files to mcpserver@arm.com for added helpful troubleshooting context."
         ),
     }

--- a/mcp-local/utils/invocation_logger.py
+++ b/mcp-local/utils/invocation_logger.py
@@ -18,14 +18,10 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional, Dict, Any
 
-import yaml
-
 from .config import WORKSPACE_DIR
 
 
-LOG_FILE_NAME = "invocation_reasons.yaml"
-MCP_TRAFFIC_LOG_ENV = "MCP_LOG_FILE"
-MCP_TRAFFIC_LOG_DEFAULT = "/workspace/mcp-traffic.jsonl"
+LOG_FILE_NAME = "mcp-traffic.jsonl"
 
 
 def _now_iso() -> str:
@@ -38,32 +34,13 @@ def log_invocation_reason(
     args: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
-    Append a YAML document with the tool invocation reason and metadata to /workspace/invocation_reasons.yaml.
-    Also append a JSONL call entry to MCP_LOG_FILE.
+    Append a JSONL call entry to the workspace traffic log.
 
     Returns the entry ID so the caller can pair the tool result with this invocation.
     Errors are swallowed to avoid impacting tool execution.
     """
     entry_id = str(uuid.uuid4())
     timestamp = _now_iso()
-
-    if reason:
-        entry = {
-            "id": entry_id,
-            "timestamp": timestamp,
-            "tool": tool,
-            "args": args or {},
-            "reason": str(reason),
-        }
-
-        log_path = os.path.join(WORKSPACE_DIR, LOG_FILE_NAME)
-
-        try:
-            os.makedirs(WORKSPACE_DIR, exist_ok=True)
-            with open(log_path, "a", encoding="utf-8") as f:
-                yaml.safe_dump(entry, f, explicit_start=True, sort_keys=False, allow_unicode=True)
-        except Exception:
-            pass
 
     traffic_entry = {
         "id": entry_id,
@@ -72,10 +49,10 @@ def log_invocation_reason(
         "args": args or {},
         "invocation_reason": reason,
     }
-    traffic_path = os.environ.get(MCP_TRAFFIC_LOG_ENV, MCP_TRAFFIC_LOG_DEFAULT)
+    log_path = os.path.join(WORKSPACE_DIR, LOG_FILE_NAME)
     try:
-        os.makedirs(os.path.dirname(traffic_path) or WORKSPACE_DIR, exist_ok=True)
-        with open(traffic_path, "a", encoding="utf-8") as f:
+        os.makedirs(WORKSPACE_DIR, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(traffic_entry) + "\n")
     except Exception:
         pass
@@ -85,7 +62,7 @@ def log_invocation_reason(
 
 def log_tool_result(entry_id: str, tool: str, result: Any) -> None:
     """Append a JSONL result entry paired with a tool invocation."""
-    traffic_path = os.environ.get(MCP_TRAFFIC_LOG_ENV, MCP_TRAFFIC_LOG_DEFAULT)
+    log_path = os.path.join(WORKSPACE_DIR, LOG_FILE_NAME)
     result_entry = {
         "id": entry_id,
         "type": "result",
@@ -93,8 +70,8 @@ def log_tool_result(entry_id: str, tool: str, result: Any) -> None:
         "result": result,
     }
     try:
-        os.makedirs(os.path.dirname(traffic_path) or WORKSPACE_DIR, exist_ok=True)
-        with open(traffic_path, "a", encoding="utf-8") as f:
+        os.makedirs(WORKSPACE_DIR, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(result_entry, default=str) + "\n")
     except Exception:
         pass

--- a/mcp-local/utils/migrate_ease_utils.py
+++ b/mcp-local/utils/migrate_ease_utils.py
@@ -35,9 +35,7 @@ EXCLUDE_PATTERNS: Set[str] = {
     '.git', '.svn', '.hg',
     # IDE and editor directories
     '.vscode', '.idea', '.eclipse',
-    # MCP server logs
-    'mcp-traffic.jsonl', 'error_logging.yaml', 'invocation_reasons.yaml',
-    # Other common build/cache directories
+    'mcp-traffic.jsonl', 'error_logging.yaml',
     'target', 'out', '.cache',
 }
 

--- a/mcp-local/utils/migrate_ease_utils.py
+++ b/mcp-local/utils/migrate_ease_utils.py
@@ -35,6 +35,8 @@ EXCLUDE_PATTERNS: Set[str] = {
     '.git', '.svn', '.hg',
     # IDE and editor directories
     '.vscode', '.idea', '.eclipse',
+    # MCP server logs
+    'mcp-traffic.jsonl', 'error_logging.yaml', 'invocation_reasons.yaml',
     # Other common build/cache directories
     'target', 'out', '.cache',
 }


### PR DESCRIPTION
Follow up to #124 

### Summary
- Remove the duplicate invocation_reasons.yaml logging.
- Keep tool calls in /workspace/mcp-traffic.jsonl, with results logged for knowledge base searches.
- Retain the existing /workspace/error_logging.yaml diagnostics.
- Standardize both log paths around WORKSPACE_DIR.
- Document the generated log files in the README.
- Exclude log files from migrate-ease scans and Git tracking.
- Fix logger test imports and add the unit tests to CI.