### PR TITLE
Add dependabot version scanning config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     # A root entry scans workflows under .github/workflows.
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       github-actions:
         patterns:
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/embedding-generation"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       embedding-dependencies:
         patterns:
@@ -23,7 +23,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/mcp-local"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       mcp-local-dependencies:
         patterns:
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       root-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     # A root entry scans workflows under .github/workflows.
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     groups:
       github-actions:
         patterns:
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/embedding-generation"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     groups:
       embedding-dependencies:
         patterns:
@@ -23,7 +23,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/mcp-local"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     groups:
       mcp-local-dependencies:
         patterns:
@@ -34,7 +34,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"
     groups:
       root-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    # A root entry scans workflows under .github/workflows.
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "uv"
+    directory: "/embedding-generation"
+    schedule:
+      interval: "weekly"
+
+  # Root project (used for arm-kb-search) is PEP 621
+  # but doesn't currently have a uv lockfile.
+  # Move mcp-local to a separate uv entry after its lockfile migration.
+  - package-ecosystem: "pip"
+    directories:
+      - "/"
+      - "/mcp-local"
+      - "/mcp-local/tests"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,19 +6,36 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "uv"
     directory: "/embedding-generation"
     schedule:
       interval: "weekly"
+    groups:
+      embedding-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/mcp-local"
+    schedule:
+      interval: "weekly"
+    groups:
+      mcp-local-dependencies:
+        patterns:
+          - "*"
 
   # Root project (used for arm-kb-search) is PEP 621
   # but doesn't currently have a uv lockfile.
-  # Move mcp-local to a separate uv entry after its lockfile migration.
   - package-ecosystem: "pip"
-    directories:
-      - "/"
-      - "/mcp-local"
-      - "/mcp-local/tests"
+    directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      root-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds Dependabot version scanning for Github Actions workflows and our various `uv`/`pip` environments. This is in addition to the security scanning that is already present. To reduce the amount of PR noise, I've set it to run monthly and group all updates into one PR for each package manager environment. We can easily change this to more or less often as desired in the future.