### PR TITLE
Remove refs to secure-build, update MCP input bundle

### DIFF
--- a/.github/workflows/embedding-unit-tests.yml
+++ b/.github/workflows/embedding-unit-tests.yml
@@ -2,12 +2,12 @@ name: Embedding Generation Unit Tests
 
 on:
   push:
-    branches: [main, secure-build]
+    branches: [main]
     paths:
       - 'embedding-generation/**'
       - '.github/workflows/embedding-unit-tests.yml'
   pull_request:
-    branches: [main, secure-build]
+    branches: [main]
     paths:
       - 'embedding-generation/**'
       - '.github/workflows/embedding-unit-tests.yml'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,7 +14,7 @@ on:
     branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main", "secure-build", "stesol-576-ossf-scorecard" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 # Declare default permissions as read only.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ currently approved input bundle is recorded in
 `mcp-local/build-inputs.lock.json` and defaults to:
 
 ```text
-ghcr.io/arm/mcp-build-inputs@sha256:d38c64ad12493ddacfe7a99e49f47e6cfcf1f9d2acf1696c797645d3099758a3
+ghcr.io/arm/mcp-build-inputs@sha256:8db95af8e7d819b82adbed0bd1c9eadcd1d0f2afdd144c52618b58bccfbf07cf
 ```
 
 ### Why the Build Uses Multiple Dockerfiles
@@ -330,7 +330,7 @@ target, key mounts, and Java workload configured in
 The index and its platform manifests can be inspected without unpacking it:
 
 ```bash
-MCP_INPUTS="ghcr.io/arm/mcp-build-inputs@sha256:d38c64ad12493ddacfe7a99e49f47e6cfcf1f9d2acf1696c797645d3099758a3"
+MCP_INPUTS="ghcr.io/arm/mcp-build-inputs@sha256:8db95af8e7d819b82adbed0bd1c9eadcd1d0f2afdd144c52618b58bccfbf07cf"
 docker buildx imagetools inspect "$MCP_INPUTS"
 docker buildx imagetools inspect "$MCP_INPUTS" --format '{{json .Manifest}}' | jq
 ```

--- a/embedding-generation/README.md
+++ b/embedding-generation/README.md
@@ -99,7 +99,7 @@ Leave the column empty for sources that are chunked from their primary `URL`.
 Install dependencies once:
 
 ```sh
-uv sync --frozen
+uv sync --locked
 ```
 
 Python 3.13 is required.
@@ -107,7 +107,7 @@ Python 3.13 is required.
 Run the full local question eval:
 
 ```sh
-uv run ./run-question-eval.sh
+uv run --locked ./run-question-eval.sh
 ```
 
 That command copies intrinsic chunks from the embedding base image if needed,
@@ -118,16 +118,16 @@ without model network access.
 Useful options:
 
 ```sh
-uv run ./run-question-eval.sh --refresh-intrinsic-chunks
-uv run ./run-question-eval.sh --eval eval_questions.json --top-k 5
-SKIP_DISCOVERY=1 uv run ./run-question-eval.sh
+uv run --locked ./run-question-eval.sh --refresh-intrinsic-chunks
+uv run --locked ./run-question-eval.sh --eval eval_questions.json --top-k 5
+SKIP_DISCOVERY=1 uv run --locked ./run-question-eval.sh
 ```
 
 Run lint and tests with:
 
 ```sh
-uv run ruff check .
-uv run pytest
+uv run --locked ruff check .
+uv run --locked pytest
 ```
 
 To check a new document, add or update a question in `eval_questions.json` with the document URL in `expected_urls`, then run the wrapper. Review `Hit@1`, `Hit@3`, `Hit@5`, `MRR`, and any printed misses before committing the CSV change.

--- a/mcp-local/Dockerfile
+++ b/mcp-local/Dockerfile
@@ -16,7 +16,7 @@
 
 # Keep these defaults synchronized with mcp-local/build-inputs.lock.json.
 ARG EMBEDDINGS_IMAGE=ghcr.io/arm/mcp-embedding-vectorstore@sha256:724a53a6a8b29893c196c406a6ba9a41a1ec3b122b7aa2ceb587a67991519f88
-ARG MCP_BUILD_INPUTS_IMAGE=ghcr.io/arm/mcp-build-inputs@sha256:d38c64ad12493ddacfe7a99e49f47e6cfcf1f9d2acf1696c797645d3099758a3
+ARG MCP_BUILD_INPUTS_IMAGE=ghcr.io/arm/mcp-build-inputs@sha256:8db95af8e7d819b82adbed0bd1c9eadcd1d0f2afdd144c52618b58bccfbf07cf
 ARG UBUNTU_IMAGE=ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
 FROM ${MCP_BUILD_INPUTS_IMAGE} AS mcp-inputs

--- a/mcp-local/Dockerfile
+++ b/mcp-local/Dockerfile
@@ -67,6 +67,7 @@ RUN --network=none mkdir -p /opt/arm-migration-tools/migrate-ease && \
       printf '%s\n' \
         '#!/bin/sh' \
         'cd /opt/arm-migration-tools/migrate-ease' \
+        'export PYTHONPATH="/opt/arm-migration-tools/migrate-ease${PYTHONPATH:+:$PYTHONPATH}"' \
         "exec /app/.venv/bin/python -m ${scanner} \"\$@\"" \
         > "${wrapper}"; \
       chmod 0755 "${wrapper}"; \

--- a/mcp-local/build-inputs.lock.json
+++ b/mcp-local/build-inputs.lock.json
@@ -35,14 +35,14 @@
       "verification": "private GHCR OCI image-index digest"
     },
     "mcp_build_inputs": {
-      "reference": "ghcr.io/arm/mcp-build-inputs@sha256:d38c64ad12493ddacfe7a99e49f47e6cfcf1f9d2acf1696c797645d3099758a3",
+      "reference": "ghcr.io/arm/mcp-build-inputs@sha256:8db95af8e7d819b82adbed0bd1c9eadcd1d0f2afdd144c52618b58bccfbf07cf",
       "architectures": [
         "amd64",
         "arm64"
       ],
       "manifests": {
-        "amd64": "ghcr.io/arm/mcp-build-inputs@sha256:1ed42f63142046d20a26bc99ec1a6d2195cb049711a5a36e85b350177af1392a",
-        "arm64": "ghcr.io/arm/mcp-build-inputs@sha256:eae03c0148f6db8833183a0323c3df7b2614c29e5d9aa24b854dec07cc2e1491"
+        "amd64": "ghcr.io/arm/mcp-build-inputs@sha256:7f9d02a8c74587bb74a7b1285f3b56c4e07c9dcf2b9e0aeb1ced6c20cf4d7a7b",
+        "arm64": "ghcr.io/arm/mcp-build-inputs@sha256:702d6d414b058f7c701abe18f0ad91c833fd5901066250a3426f18aa151cd39f"
       },
       "contents": [
         "/mcp-build-inputs/wheels/",
@@ -51,8 +51,8 @@
         "/mcp-build-inputs/migrate-ease.tar.gz",
         "/mcp-build-inputs/metadata/"
       ],
-      "source_revision": "386329f3bbf42d76d4f6f8cede9d7273064c3065",
-      "workflow_run": "31226100313",
+      "source_revision": "6e3a3e1c1fc6019ceaaa617ca484091cd6592b8f",
+      "workflow_run": "32304653420",
       "verification": "private multi-architecture GHCR OCI image-index digest"
     }
   },

--- a/mcp-local/tests/test_build_inputs.py
+++ b/mcp-local/tests/test_build_inputs.py
@@ -120,6 +120,10 @@ def test_dockerfile_consumes_only_staged_third_party_inputs() -> None:
     assert "--from=mcp-inputs /mcp-build-inputs/debs/runtime/" in DOCKERFILE
     assert "--from=mcp-inputs /mcp-build-inputs/performix.tar.gz" in DOCKERFILE
     assert "--from=mcp-inputs /mcp-build-inputs/migrate-ease.tar.gz" in DOCKERFILE
+    assert (
+        'export PYTHONPATH="/opt/arm-migration-tools/migrate-ease'
+        '${PYTHONPATH:+:$PYTHONPATH}"'
+    ) in DOCKERFILE
     assert "mcp-local/build-inputs/" not in DOCKERFILE
     assert "!mcp-local/build-inputs/" not in ROOT_DOCKERIGNORE
     assert "--from=embeddings /embedding-data/embedding-model/" in DOCKERFILE

--- a/mcp-local/tests/test_mcp.py
+++ b/mcp-local/tests/test_mcp.py
@@ -205,8 +205,21 @@ def test_mcp_stdio_transport_responds(platform):
             #Check Migrate Ease Tool Test
             raw_socket.sendall(_encode_mcp_message(constants.CHECK_MIGRATE_EASE_TOOL_REQUEST))
             check_migrate_ease_tool_response = _read_response(5, timeout=60)
-            #assert only the status field to avoid mismatches due to dynamic fields
-            assert check_migrate_ease_tool_response.get("result")["structuredContent"]["status"] == constants.EXPECTED_CHECK_MIGRATE_EASE_TOOL_RESPONSE_STATUS, "Test Failed: MCP check_migrate_ease_tool tool failed: status mismatch. Expected: {}, Received: {}".format(constants.EXPECTED_CHECK_MIGRATE_EASE_TOOL_RESPONSE_STATUS, check_migrate_ease_tool_response.get("result")["structuredContent"]["status"])
+            # Assert only the status field to avoid mismatches due to dynamic fields.
+            migrate_ease_content = check_migrate_ease_tool_response.get("result")[
+                "structuredContent"
+            ]
+            assert (
+                migrate_ease_content["status"]
+                == constants.EXPECTED_CHECK_MIGRATE_EASE_TOOL_RESPONSE_STATUS
+            ), (
+                "Test Failed: MCP check_migrate_ease_tool tool failed: status "
+                "mismatch. Expected: {}, Received: {}\nFull response: {}".format(
+                    constants.EXPECTED_CHECK_MIGRATE_EASE_TOOL_RESPONSE_STATUS,
+                    migrate_ease_content["status"],
+                    json.dumps(migrate_ease_content, indent=2),
+                )
+            )
             print("\n***Test Passed: MCP check_migrate_ease_tool tool succeeded")
 
             #Check Sysreport Tool Test


### PR DESCRIPTION
### Summary

- Updates the pinned MCP input bundle.
- Removes remaining secure-build workflow references.
- Fixes migrate-ease startup with the newly pinned source revision.

The newer migrate-ease revision added [a preflight check](https://github.com/migrate-ease/migrate-ease/pull/50) requiring its project root to be explicitly present in `PYTHONPATH`. The previous wrapper only changed directories, so scans exited with an error. The wrapper now exports the migrate-ease root before launching while preserving any existing `PYTHONPATH`.
The integration test also reports the full migrate-ease response on failure for easier diagnosis.