### PR TITLE
Codeowners and release flow updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Release and supply-chain files require approval from the MCP security team.
+# Files not matched below remain reviewable by any authorized organization
+# member under the repository's normal branch rules.
+/.github/CODEOWNERS @arm/mcp-security-team
+/.github/workflows/ @arm/mcp-security-team
+/.github/scripts/ @arm/mcp-security-team
+/mcp-local/Dockerfile @arm/mcp-security-team
+/mcp-local/Dockerfile.inputs @arm/mcp-security-team
+/mcp-local/server.json @arm/mcp-security-team
+/mcp-local/build-inputs.lock.json @arm/mcp-security-team
+/mcp-local/pyproject.toml @arm/mcp-security-team
+/mcp-local/uv.lock @arm/mcp-security-team
+/mcp-local/scripts/stage-build-inputs.py @arm/mcp-security-team
+/embedding-generation/Dockerfile.acquire @arm/mcp-security-team
+/embedding-generation/Dockerfile.toolchain @arm/mcp-security-team
+/embedding-generation/Dockerfile.vectorstore @arm/mcp-security-team
+/embedding-generation/embedding-model.lock.json @arm/mcp-security-team
+/embedding-generation/pipeline-inputs.lock.json @arm/mcp-security-team
+/embedding-generation/pyproject.toml @arm/mcp-security-team
+/embedding-generation/uv.lock @arm/mcp-security-team

--- a/.github/scripts/bump_mcp_version.py
+++ b/.github/scripts/bump_mcp_version.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Update the MCP server metadata to a reviewed release version."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+DEFAULT_SERVER_FILE = REPOSITORY / "mcp-local" / "server.json"
+RELEASE_IMAGE = "docker.io/armlimited/arm-mcp"
+
+
+def prepare_version_bump(server_file: Path, bump_type: str) -> tuple[dict, str]:
+    server = json.loads(server_file.read_text(encoding="utf-8"))
+    current_version = server.get("version")
+    match = re.fullmatch(r"([0-9]+)\.([0-9]+)\.([0-9]+)", current_version or "")
+    if not match:
+        raise ValueError(f"invalid MCP release version: {current_version}")
+
+    current_identifier = f"{RELEASE_IMAGE}:{current_version}"
+    release_packages = [
+        package
+        for package in server.get("packages", [])
+        if package.get("registryType") == "oci"
+        and package.get("identifier") == current_identifier
+    ]
+    if len(release_packages) != 1:
+        raise ValueError(
+            f"server.json must contain exactly one OCI package for {current_identifier}"
+        )
+
+    major, minor, patch = (int(part) for part in match.groups())
+    if bump_type == "major":
+        next_version = f"{major + 1}.0.0"
+    elif bump_type == "minor":
+        next_version = f"{major}.{minor + 1}.0"
+    elif bump_type == "hotfix":
+        next_version = f"{major}.{minor}.{patch + 1}"
+    else:
+        raise ValueError(f"unsupported release type: {bump_type}")
+
+    server["version"] = next_version
+    release_packages[0]["identifier"] = f"{RELEASE_IMAGE}:{next_version}"
+    return server, next_version
+
+
+def write_version_bump(server_file: Path, bump_type: str) -> str:
+    server, next_version = prepare_version_bump(server_file, bump_type)
+    server_file.write_text(json.dumps(server, indent=2) + "\n", encoding="utf-8")
+    return next_version
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--bump-type", choices=("major", "minor", "hotfix"), required=True
+    )
+    parser.add_argument("--server-file", type=Path, default=DEFAULT_SERVER_FILE)
+    args = parser.parse_args()
+    print(write_version_bump(args.server_file, args.bump_type))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/dispatch-required-pr-checks.sh
+++ b/.github/scripts/dispatch-required-pr-checks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ] || [ -z "$1" ]; then
+  echo "usage: $0 <branch>" >&2
+  exit 2
+fi
+
+branch="$1"
+# Keep this list synchronized with the status checks required by the main
+# branch ruleset. Each workflow must support workflow_dispatch.
+workflows=(
+  integration-tests.yml
+  embedding-unit-tests.yml
+  scorecard.yml
+)
+
+for workflow in "${workflows[@]}"; do
+  gh workflow run "${workflow}" --ref "${branch}"
+  echo "Dispatched ${workflow} for ${branch}."
+done

--- a/.github/scripts/update-mcp-embedding-pin.py
+++ b/.github/scripts/update-mcp-embedding-pin.py
@@ -51,6 +51,13 @@ def update_pin(
     lock = json.loads(lock_file.read_text(encoding="utf-8"))
     embeddings = lock["container_images"]["embeddings"]
     previous_reference = embeddings["reference"]
+
+    # A new workflow run can reproduce the exact image digest. Preserve the
+    # reviewed provenance and release version in that case: there is no new
+    # build input to promote.
+    if reference == previous_reference:
+        return
+
     previous_arg = f"ARG EMBEDDINGS_IMAGE={previous_reference}"
 
     dockerfile_text = dockerfile.read_text(encoding="utf-8")

--- a/.github/scripts/update-mcp-embedding-pin.py
+++ b/.github/scripts/update-mcp-embedding-pin.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Keep the checked-in MCP embedding image pins synchronized."""
+"""Prepare a reviewed MCP release by pinning embeddings and bumping version."""
 
 from __future__ import annotations
 
@@ -8,10 +8,13 @@ import json
 from pathlib import Path
 import re
 
+from bump_mcp_version import prepare_version_bump
+
 
 REPOSITORY = Path(__file__).resolve().parents[2]
 DEFAULT_LOCK = REPOSITORY / "mcp-local" / "build-inputs.lock.json"
 DEFAULT_DOCKERFILE = REPOSITORY / "mcp-local" / "Dockerfile"
+DEFAULT_SERVER_FILE = REPOSITORY / "mcp-local" / "server.json"
 REFERENCE_PATTERN = re.compile(
     r"^ghcr\.io/[A-Za-z0-9_.-]+/mcp-embedding-vectorstore@sha256:[0-9a-f]{64}$"
 )
@@ -25,6 +28,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--workflow-run", required=True)
     parser.add_argument("--lock-file", type=Path, default=DEFAULT_LOCK)
     parser.add_argument("--dockerfile", type=Path, default=DEFAULT_DOCKERFILE)
+    parser.add_argument("--server-file", type=Path, default=DEFAULT_SERVER_FILE)
     return parser.parse_args()
 
 
@@ -35,6 +39,7 @@ def update_pin(
     workflow_run: str,
     lock_file: Path,
     dockerfile: Path,
+    server_file: Path,
 ) -> None:
     if not REFERENCE_PATTERN.fullmatch(reference):
         raise ValueError(f"invalid immutable embedding reference: {reference}")
@@ -54,6 +59,8 @@ def update_pin(
             "Dockerfile EMBEDDINGS_IMAGE does not match the checked-in manifest"
         )
 
+    server, next_version = prepare_version_bump(server_file, "minor")
+
     embeddings["reference"] = reference
     embeddings["source_revision"] = source_revision
     embeddings["workflow_run"] = workflow_run
@@ -62,6 +69,7 @@ def update_pin(
         dockerfile_text.replace(previous_arg, f"ARG EMBEDDINGS_IMAGE={reference}"),
         encoding="utf-8",
     )
+    server_file.write_text(json.dumps(server, indent=2) + "\n", encoding="utf-8")
 
 
 def main() -> None:
@@ -72,6 +80,7 @@ def main() -> None:
         workflow_run=args.workflow_run,
         lock_file=args.lock_file,
         dockerfile=args.dockerfile,
+        server_file=args.server_file,
     )
 
 

--- a/.github/workflows/build-embeddings.yml
+++ b/.github/workflows/build-embeddings.yml
@@ -228,6 +228,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
+      actions: write
       # Required only for pushing the reviewed promotion branch. GitHub token
       # permissions cannot be narrowed to an individual step.
       contents: write
@@ -241,9 +242,6 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          # A bot/App token is required so the generated PR starts required
-          # pull_request checks; events from github.token are suppressed.
-          token: ${{ secrets.RELEASE_PR_TOKEN }}
 
       - name: Update checked-in embedding pin and release version
         id: update
@@ -269,7 +267,7 @@ jobs:
       - name: Push promotion branch and open or update PR
         if: ${{ steps.update.outputs.changed == 'true' }}
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.update.outputs.release_version }}
         shell: bash
         run: |
@@ -311,6 +309,8 @@ jobs:
               --title "chore: promote embeddings for ${RELEASE_VERSION}" \
               --body-file "${body_file}"
           fi
+
+          .github/scripts/dispatch-required-pr-checks.sh "${PROMOTION_BRANCH}"
 
           {
             echo "### MCP embedding promotion"

--- a/.github/workflows/build-embeddings.yml
+++ b/.github/workflows/build-embeddings.yml
@@ -241,8 +241,11 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # A bot/App token is required so the generated PR starts required
+          # pull_request checks; events from github.token are suppressed.
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
 
-      - name: Update checked-in embedding pin
+      - name: Update checked-in embedding pin and release version
         id: update
         shell: bash
         run: |
@@ -253,7 +256,10 @@ jobs:
             --source-revision "${GITHUB_SHA}" \
             --workflow-run "${GITHUB_RUN_ID}"
 
-          if git diff --quiet -- mcp-local/Dockerfile mcp-local/build-inputs.lock.json; then
+          release_version="$(jq -er '.version' mcp-local/server.json)"
+          echo "release_version=${release_version}" >> "${GITHUB_OUTPUT}"
+
+          if git diff --quiet -- mcp-local/Dockerfile mcp-local/build-inputs.lock.json mcp-local/server.json; then
             echo "changed=false" >> "${GITHUB_OUTPUT}"
             echo "The generated vector store already matches the checked-in MCP pin." >> "${GITHUB_STEP_SUMMARY}"
           else
@@ -263,14 +269,15 @@ jobs:
       - name: Push promotion branch and open or update PR
         if: ${{ steps.update.outputs.changed == 'true' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+          RELEASE_VERSION: ${{ steps.update.outputs.release_version }}
         shell: bash
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add mcp-local/Dockerfile mcp-local/build-inputs.lock.json
-          git commit -m "chore: promote embedding vector store"
+          git add mcp-local/Dockerfile mcp-local/build-inputs.lock.json mcp-local/server.json
+          git commit -m "chore: promote embeddings for ${RELEASE_VERSION}"
 
           git fetch origin "${PROMOTION_BRANCH}:refs/remotes/origin/${PROMOTION_BRANCH}" || true
           git push --force-with-lease origin "HEAD:refs/heads/${PROMOTION_BRANCH}"
@@ -282,8 +289,9 @@ jobs:
           - Source revision: \`${GITHUB_SHA}\`
           - Workflow run: [${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
           - Candidate: \`${EMBEDDINGS_REFERENCE}\`
+          - Proposed MCP version: \`${RELEASE_VERSION}\`
 
-          This PR updates both the checked-in build-input manifest and the Dockerfile default. Merging it triggers a minor MCP release using this exact digest.
+          This PR updates the checked-in build-input manifest, Dockerfile default, and MCP release version. Merging the reviewed PR releases an MCP image using this exact digest.
           EOF
 
           pr_url="$(gh pr list \
@@ -296,11 +304,11 @@ jobs:
             pr_url="$(gh pr create \
               --base main \
               --head "${PROMOTION_BRANCH}" \
-              --title "chore: promote embedding vector store" \
+              --title "chore: promote embeddings for ${RELEASE_VERSION}" \
               --body-file "${body_file}")"
           else
             gh pr edit "${pr_url}" \
-              --title "chore: promote embedding vector store" \
+              --title "chore: promote embeddings for ${RELEASE_VERSION}" \
               --body-file "${body_file}"
           fi
 
@@ -309,6 +317,7 @@ jobs:
             echo ""
             echo "- Pull request: ${pr_url}"
             echo "- Candidate: \`${EMBEDDINGS_REFERENCE}\`"
+            echo "- Proposed MCP version: \`${RELEASE_VERSION}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
   verify-vectorstore-provenance:
     needs: generate-and-publish-vectorstore

--- a/.github/workflows/build-mcp-image.yml
+++ b/.github/workflows/build-mcp-image.yml
@@ -2,7 +2,6 @@ name: Build MCP Image
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
     branches: [main]
     paths:
       - mcp-local/server.json
@@ -298,11 +297,10 @@ jobs:
           SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
         run: |
           set -euo pipefail
-          notes_file="${RUNNER_TEMP}/release-notes.md"
-          printf 'Docker image: `%s:%s`\n\nSource commit: `%s`\n' \
-            "${IMAGE}" "${VERSION}" "${SOURCE_SHA}" > "${notes_file}"
+          notes="$(printf 'Docker image: `%s:%s`\n\nSource commit: `%s`' \
+            "${IMAGE}" "${VERSION}" "${SOURCE_SHA}")"
           gh release create "v${VERSION}" \
             --target "${SOURCE_SHA}" \
             --title "v${VERSION}" \
             --generate-notes \
-            --notes-file "${notes_file}"
+            --notes "${notes}"

--- a/.github/workflows/build-mcp-image.yml
+++ b/.github/workflows/build-mcp-image.yml
@@ -2,58 +2,162 @@ name: Build MCP Image
 
 on:
   pull_request:
-    types: [closed]
+    types: [opened, synchronize, reopened]
     branches: [main]
     paths:
-      - mcp-local/Dockerfile
-      - mcp-local/build-inputs.lock.json
+      - mcp-local/server.json
+  push:
+    branches: [main]
+    paths:
+      - mcp-local/server.json
   workflow_dispatch:
     inputs:
-      bump_type:
-        description: "Manual version bump. Minor is automatic when a reviewed embedding-promotion PR merges."
+      release_action:
+        description: Build without publishing, or propose a reviewed release PR
         type: choice
         options:
-          - major
-          - minor
+          - dry-run
           - hotfix
-        default: major
-      dry_run:
-        description: "Build without pushing images, manifests, or git tags"
-        type: boolean
-        default: false
+          - minor
+          - major
+        default: dry-run
 
 permissions:
   contents: read
 
-# Shared expressions, exported to every run step and usable in step if:/with:
-# (env context). NOTE: `concurrency` below can't read env (github/inputs/vars
-# only), so that one main+dry check stays inline.
 env:
   IMAGE: armlimited/arm-mcp
-  IS_MAIN: ${{ (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
-  IS_DRY_RUN: ${{ github.event.inputs.dry_run == true || github.event.inputs.dry_run == 'true' }}
 
-# Serialize only publishing runs so overlapping builds can't race on
-# computing/publishing the same auto-incremented version (alias + git tag).
-# Publishing runs (from main, not dry_run) share a single static group so they
-# queue behind one another. Non-publishing runs (dry_run or non-main) never
-# touch shared version/tag state, so they get a unique per-run group and run
-# concurrently without blocking the publishing queue.
+# Version PRs serialize naturally at merge time, but publication remains
+# serialized so two closely spaced releases cannot race when updating latest.
 concurrency:
-  group: >-
-    ${{
-      (
-        ((github.event_name == 'pull_request' && github.event.pull_request.merged == true) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'))
-        && !(github.event.inputs.dry_run == true || github.event.inputs.dry_run == 'true')
-      )
-      && 'build-mcp-image-publish'
-      || format('build-mcp-image-{0}', github.run_id)
-    }}
+  group: ${{ github.event_name == 'push' && 'build-mcp-image-publish' || format('build-mcp-image-{0}', github.run_id) }}
   cancel-in-progress: false
 
 jobs:
+  propose-version:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.release_action != 'dry-run' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+          # A bot/App token is required so the generated PR starts required
+          # pull_request checks; events from github.token are suppressed.
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
+
+      - name: Open or update reviewed version PR
+        shell: bash
+        env:
+          BUMP_TYPE: ${{ inputs.release_action }}
+          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+        run: |
+          set -euo pipefail
+          branch="automation/release-${BUMP_TYPE}"
+          git checkout -B "${branch}"
+          version="$(python3 .github/scripts/bump_mcp_version.py --bump-type "${BUMP_TYPE}")"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add mcp-local/server.json
+          git commit -m "chore: propose ${BUMP_TYPE} release ${version}"
+
+          git fetch origin "${branch}:refs/remotes/origin/${branch}" || true
+          git push --force-with-lease origin "HEAD:refs/heads/${branch}"
+
+          body="Proposes reviewed ${BUMP_TYPE} release \`${version}\`. Merging this PR triggers the release workflow."
+          pr_url="$(gh pr list \
+            --base main \
+            --head "${branch}" \
+            --state open \
+            --json url \
+            --jq '.[0].url // empty')"
+          if [ -z "${pr_url}" ]; then
+            pr_url="$(gh pr create \
+              --base main \
+              --head "${branch}" \
+              --title "chore: propose ${BUMP_TYPE} release ${version}" \
+              --body "${body}")"
+          else
+            gh pr edit "${pr_url}" \
+              --title "chore: propose ${BUMP_TYPE} release ${version}" \
+              --body "${body}"
+          fi
+
+          {
+            echo "### Reviewed release proposal"
+            echo ""
+            echo "- Type: ${BUMP_TYPE}"
+            echo "- Version: \`${version}\`"
+            echo "- Pull request: ${pr_url}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  validate-release:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.release_action == 'dry-run' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      source_sha: ${{ steps.release.outputs.source_sha }}
+      publish: ${{ steps.release.outputs.publish }}
+      build: ${{ steps.release.outputs.build }}
+    steps:
+      - name: Checkout reviewed release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Validate reviewed release version
+        id: release
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          CHECK_TAG: ${{ github.event_name != 'workflow_dispatch' }}
+          BUILD: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
+          PUBLISH: ${{ github.event_name == 'push' }}
+        run: |
+          set -euo pipefail
+          server_file="mcp-local/server.json"
+          version="$(jq -er '.version | select(type == "string")' "${server_file}")"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::server.json version must use X.Y.Z semantic versioning: ${version}"
+            exit 1
+          fi
+
+          expected_image="docker.io/${IMAGE}:${version}"
+          if ! jq -e --arg image "${expected_image}" '
+            [.packages[]? | select(.registryType == "oci") | .identifier] | index($image) != null
+          ' "${server_file}" > /dev/null; then
+            echo "::error::server.json must identify the release image as ${expected_image}."
+            exit 1
+          fi
+
+          if [ "${CHECK_TAG}" = "true" ] && git rev-parse -q --verify "refs/tags/v${version}" > /dev/null; then
+            echo "::error::Release tag v${version} already exists. Submit a new reviewed version PR."
+            exit 1
+          fi
+
+          {
+            echo "version=${version}"
+            echo "source_sha=${SOURCE_SHA}"
+            echo "publish=${PUBLISH}"
+            echo "build=${BUILD}"
+          } >> "${GITHUB_OUTPUT}"
+
+          if [ "${BUILD}" = "true" ] && [ "${PUBLISH}" != "true" ]; then
+            echo "Manual runs validate and build the selected commit but never publish." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
   build-arch-images:
-    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'automation/pin-embedding-vectorstore') }}
+    needs: validate-release
+    if: ${{ needs.validate-release.outputs.build == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -68,52 +172,11 @@ jobs:
     permissions:
       contents: read
       packages: read
-    outputs:
-      build_date: ${{ steps.build_date.outputs.build_date }}
-      date_tag: ${{ steps.build_date.outputs.date_tag }}
     steps:
-      - name: Guard against non-main publishing
-        run: |
-          # workflow_dispatch can be started from any branch (GitHub has no
-          # branch filter for it). Publishing is main-only; non-main runs are
-          # allowed solely as dry_run validation, else fail fast.
-          if [ "${IS_MAIN}" != "true" ] && [ "${IS_DRY_RUN}" != "true" ]; then
-            echo "::error::Non-main runs must set dry_run=true (build/validate only, never publish)."
-            exit 1
-          fi
-          # Block publishing reruns: the version derives from existing git
-          # tags, so re-running after a tag was pushed would publish a NEW
-          # version for the same build. Reruns bump run_attempt; require
-          # attempt 1. Start a fresh run to recover instead.
-          if [ "${IS_DRY_RUN}" != "true" ] && [ "${{ github.run_attempt }}" != "1" ]; then
-            echo "::error::Publishing reruns are disabled (would republish a new version). Start a fresh workflow run instead."
-            exit 1
-          fi
-
-      - name: Checkout
+      - name: Checkout reviewed release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # Build the exact merge commit for an embedding promotion, or the
-          # selected commit for a manual run. The git tag is created later at
-          # the server.json bump commit, not this commit.
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
-
-      - name: Set build date and unique date tag (UTC)
-        id: build_date
-        run: |
-          if [ -n "${{ github.event.pull_request.merged_at }}" ]; then
-            BUILD_DATE=$(date -u -d "${{ github.event.pull_request.merged_at }}" +%Y-%m-%d)
-          else
-            BUILD_DATE=$(date -u +%Y-%m-%d)
-          fi
-          # Append run_number so every run gets a distinct date tag. Without it,
-          # two runs on the same day would share one tag, and the later run would
-          # alias its version/git tag onto the earlier run's image digest.
-          DATE_TAG="${BUILD_DATE}-${{ github.run_number }}"
-          echo "BUILD_DATE=$BUILD_DATE" >> "$GITHUB_ENV"
-          echo "DATE_TAG=$DATE_TAG" >> "$GITHUB_ENV"
-          echo "build_date=$BUILD_DATE" >> "$GITHUB_OUTPUT"
-          echo "date_tag=$DATE_TAG" >> "$GITHUB_OUTPUT"
+          ref: ${{ needs.validate-release.outputs.source_sha }}
 
       - name: Load locked image references
         id: locked_images
@@ -156,15 +219,13 @@ jobs:
           password: ${{ github.token }}
 
       - name: Log in to Docker Hub
-        # Only publishing runs push, so only they log in. Non-dry implies main
-        # (the top-level guard rejects non-main non-dry runs).
-        if: ${{ env.IS_DRY_RUN != 'true' }}
+        if: ${{ needs.validate-release.outputs.publish == 'true' }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push ${{ matrix.platform }} image
+      - name: Build ${{ matrix.platform }} image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
@@ -175,216 +236,73 @@ jobs:
             UBUNTU_IMAGE=${{ steps.locked_images.outputs.ubuntu_image }}
             EMBEDDINGS_IMAGE=${{ steps.locked_images.outputs.embeddings_image }}
             MCP_BUILD_INPUTS_IMAGE=${{ steps.locked_images.outputs.mcp_build_inputs_image }}
-          # Push only on publishing runs (non-dry implies main per the guard).
-          push: ${{ env.IS_DRY_RUN != 'true' }}
-          tags: ${{ env.IMAGE }}:${{ env.DATE_TAG }}-${{ matrix.tag }}
+          push: ${{ needs.validate-release.outputs.publish == 'true' }}
+          tags: ${{ env.IMAGE }}:${{ needs.validate-release.outputs.version }}-${{ matrix.tag }}
 
-  merge-manifests:
-    needs: build-arch-images
+  publish-release:
+    needs:
+      - validate-release
+      - build-arch-images
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-      pull-requests: write
     if: ${{ needs.build-arch-images.result == 'success' }}
     steps:
-      - name: Block publishing reruns
-        # Repeated from build-arch-images: "Re-run failed jobs" reruns only
-        # this job, so that job's guard won't fire, but publishing happens
-        # here. See that step for the full rationale (reruns republish a new
-        # version). Start a fresh run to recover instead.
-        if: ${{ env.IS_DRY_RUN != 'true' && github.run_attempt != 1 }}
-        run: |
-          echo "::error::Publishing reruns are disabled (would republish a new version). Start a fresh workflow run instead."
-          exit 1
-
-      - name: Checkout
+      - name: Checkout reviewed release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # Check out the promotion merge commit as the base; the
-          # bump step opens a PR from this commit and the git tag is created at
-          # the merged bump commit. fetch-depth: 0 so version tags are available.
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
-          fetch-depth: 0
+          ref: ${{ needs.validate-release.outputs.source_sha }}
+
+      - name: Record successful manual build
+        if: ${{ needs.validate-release.outputs.publish != 'true' }}
+        env:
+          VERSION: ${{ needs.validate-release.outputs.version }}
+          SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
+        run: |
+          {
+            echo "### MCP release dry run"
+            echo ""
+            echo "- Version: \`${VERSION}\`"
+            echo "- Source commit: \`${SOURCE_SHA}\`"
+            echo "- AMD64 and Arm64 builds succeeded without publication."
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Set up Docker Buildx
+        if: ${{ needs.validate-release.outputs.publish == 'true' }}
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to Docker Hub
-        # Only publishing runs write to the registry (non-dry implies main).
-        if: ${{ env.IS_DRY_RUN != 'true' }}
+        if: ${{ needs.validate-release.outputs.publish == 'true' }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Create multi-arch manifest for date tag
+      - name: Publish multi-architecture release
+        if: ${{ needs.validate-release.outputs.publish == 'true' }}
         env:
-          DATE_TAG: ${{ needs.build-arch-images.outputs.date_tag }}
-        run: |
-          if [ "${IS_DRY_RUN}" = "true" ]; then
-            echo "[dry-run] Would create ${IMAGE}:${DATE_TAG} from ${IMAGE}:${DATE_TAG}-amd64 and ${IMAGE}:${DATE_TAG}-arm64"
-            exit 0
-          fi
-          docker buildx imagetools create \
-            -t "${IMAGE}:${DATE_TAG}" \
-            "${IMAGE}:${DATE_TAG}-amd64" \
-            "${IMAGE}:${DATE_TAG}-arm64"
-
-      - name: Determine version tag
-        id: version
-        env:
-          BUMP_TYPE: ${{ github.event_name == 'pull_request' && 'minor' || github.event.inputs.bump_type }}
+          VERSION: ${{ needs.validate-release.outputs.version }}
         run: |
           set -euo pipefail
-          git fetch --tags --force --quiet
-          # `|| true`: with pipefail, grep exits non-zero when no tag matches;
-          # the explicit empty-check below emits a clearer error than set -e.
-          latest="$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)" || true
-          [ -n "${latest}" ] || { echo "::error::No vX.Y.Z tags found."; exit 1; }
-          ver="${latest#v}"
-          major="${ver%%.*}"; rest="${ver#*.}"; minor="${rest%%.*}"; patch="${rest##*.}"
-          case "${BUMP_TYPE:-minor}" in
-            major)  TAG_VERSION="$((major + 1)).0.0" ;;
-            minor)  TAG_VERSION="${major}.$((minor + 1)).0" ;;
-            hotfix) TAG_VERSION="${major}.${minor}.$((patch + 1))" ;;
-            *) echo "::error::Unknown bump_type '${BUMP_TYPE}'."; exit 1 ;;
-          esac
-          echo "${latest} -> ${TAG_VERSION} (${BUMP_TYPE})"
-          echo "tag_version=${TAG_VERSION}" >> "$GITHUB_OUTPUT"
-
-      # Merge the server.json bump FIRST so the git tag/Release below point at a
-      # main commit whose metadata already matches this version. The bump branch
-      # is created from the exact commit that produced the images.
-      - name: Bump server.json through PR
-        id: bump
-        if: ${{ env.IS_DRY_RUN != 'true' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG_VERSION: ${{ steps.version.outputs.tag_version }}
-          HEAD_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
-        run: |
-          set -euo pipefail
-          SERVER_JSON="mcp-local/server.json"
-          BUMP_BRANCH="release/server-json-${TAG_VERSION}-${GITHUB_RUN_ID}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Apply the version bump to server.json (in-memory, single write).
-          IMAGE_REF="docker.io/${IMAGE}"
-          apply_bump_file() {
-            local updated
-            if ! updated="$(jq --arg v "${TAG_VERSION}" --arg img "${IMAGE_REF}" '
-              .version = $v
-              | .packages |= map(
-                  if (.identifier // "") | startswith($img + ":")
-                  then .identifier = $img + ":" + $v
-                  else . end
-                )
-            ' "${SERVER_JSON}")"; then
-              echo "::error::jq failed to update ${SERVER_JSON}."; return 1
-            fi
-            [ -n "${updated}" ] || { echo "::error::jq produced empty output for ${SERVER_JSON}."; return 1; }
-            printf '%s\n' "${updated}" > "${SERVER_JSON}"
-          }
-
-          # Fail fast if main moved past the built commit (HEAD_SHA): committing
-          # the bump elsewhere would tag code that was never built into the
-          # image. Don't rebase -- a fresh run rebuilds from the new main.
-          git fetch origin main
-          ORIGIN_MAIN="$(git rev-parse origin/main)"
-          if [ "${ORIGIN_MAIN}" != "${HEAD_SHA}" ]; then
-            echo "::error::origin/main (${ORIGIN_MAIN}) no longer matches the built commit (${HEAD_SHA}); the image would not match the release. Start a fresh workflow run."
-            exit 1
-          fi
-
-          # Commit the bump on a release branch based on the exact commit that
-          # produced the images, then merge it through a PR so main protection is
-          # respected. If required reviews/checks block the merge, fail before
-          # publishing version aliases or the git tag.
-          git checkout -B "${BUMP_BRANCH}" "${HEAD_SHA}"
-          apply_bump_file
-          if git diff --quiet -- "${SERVER_JSON}"; then
-            echo "${SERVER_JSON} already at ${TAG_VERSION}; nothing to do."
-            echo "bump_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git add "${SERVER_JSON}"
-          git commit -m "chore: bump server.json to ${TAG_VERSION}"
-          git push origin "HEAD:refs/heads/${BUMP_BRANCH}"
-
-          PR_URL="$(gh pr create \
-            --base main \
-            --head "${BUMP_BRANCH}" \
-            --title "chore: bump server.json to ${TAG_VERSION}" \
-            --body "Automated release metadata bump for ${IMAGE}:${TAG_VERSION}.")"
-          echo "Created ${PR_URL}"
-
-          gh pr merge "${PR_URL}" \
-            --squash \
-            --delete-branch \
-            --subject "chore: bump server.json to ${TAG_VERSION}" \
-            --body "Automated release metadata bump for ${IMAGE}:${TAG_VERSION}."
-
-          git fetch origin main
-          BUMP_SHA="$(git rev-parse origin/main)"
-          echo "Merged server.json bump to ${BUMP_SHA}."
-          echo "bump_sha=${BUMP_SHA}" >> "$GITHUB_OUTPUT"
-
-      # Promote production Docker tags before the git tag (the version cursor) advances. 
-      # Self-healing via a FRESH run (reruns are blocked above): if this fails, no git tag was pushed, so a fresh run recomputes the SAME version 
-      # and overwrites these tags (imagetools create is idempotent) -- nothing to revert or clean up.
-      - name: Add latest and version aliases to date tag
-        env:
-          DATE_TAG: ${{ needs.build-arch-images.outputs.date_tag }}
-          TAG_VERSION: ${{ steps.version.outputs.tag_version }}
-        run: |
-          if [ "${IS_DRY_RUN}" = "true" ]; then
-            echo "[dry-run] Would alias ${IMAGE}:${DATE_TAG} as latest and ${TAG_VERSION}"
-            exit 0
-          fi
           docker buildx imagetools create \
+            -t "${IMAGE}:${VERSION}" \
             -t "${IMAGE}:latest" \
-            -t "${IMAGE}:${TAG_VERSION}" \
-            "${IMAGE}:${DATE_TAG}"
-          echo "Aliased ${DATE_TAG} as latest and ${TAG_VERSION}."
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-arm64"
 
-      # FINAL irreversible step: the git tag is the version cursor, so create it last. Every earlier step (bump, Docker aliases) is idempotent and
-      # leaves no tag on failure, so a FRESH run (reruns are blocked above) recomputes the SAME version and self-heals. Tag and Release are created
-      # together (both at the bump commit) to minimize the window between them.
-      - name: Create git tag and GitHub Release
+      - name: Create tag and GitHub Release
+        if: ${{ needs.validate-release.outputs.publish == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG_VERSION: ${{ steps.version.outputs.tag_version }}
-          BUMP_SHA: ${{ steps.bump.outputs.bump_sha }}
-          BUILD_DATE: ${{ needs.build-arch-images.outputs.build_date }}
+          VERSION: ${{ needs.validate-release.outputs.version }}
+          SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
         run: |
           set -euo pipefail
-          GIT_TAG="v${TAG_VERSION}"
-          if [ "${IS_DRY_RUN}" = "true" ]; then
-            echo "[dry-run] Would create git tag ${GIT_TAG} at the bump commit and publish a GitHub Release."
-            exit 0
-          fi
-
-          # Idempotent re-entry: if the Release already exists, this version was
-          # fully published on a prior run -- nothing left to do.
-          if gh release view "${GIT_TAG}" >/dev/null 2>&1; then
-            echo "Release ${GIT_TAG} already exists; nothing to do."
-            exit 0
-          fi
-
-          # Create + push the annotated tag at the bump commit (only if missing,
-          # so a re-run after a partial failure reuses it). This advances the
-          # version cursor, so it stays paired with the Release creation below.
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          if ! git rev-parse -q --verify "refs/tags/${GIT_TAG}" >/dev/null 2>&1; then
-            git tag -a "${GIT_TAG}" "${BUMP_SHA}" -m "Release ${GIT_TAG} (matches ${IMAGE}:${TAG_VERSION})"
-            git push origin "refs/tags/${GIT_TAG}"
-            echo "Created and pushed ${GIT_TAG} at ${BUMP_SHA}."
-          fi
-
-          # Publish the Release on that tag with generated notes + image line.
-          gh release create "${GIT_TAG}" --title "${GIT_TAG}" --generate-notes
-          NOTES="$(gh release view "${GIT_TAG}" --json body --jq '.body')"
-          printf 'Docker image: `%s:%s` (built %s)\n\n%s\n' "${IMAGE}" "${TAG_VERSION}" "${BUILD_DATE}" "${NOTES}" | gh release edit "${GIT_TAG}" --notes-file -
-          echo "Published GitHub Release ${GIT_TAG}."
+          notes_file="${RUNNER_TEMP}/release-notes.md"
+          printf 'Docker image: `%s:%s`\n\nSource commit: `%s`\n' \
+            "${IMAGE}" "${VERSION}" "${SOURCE_SHA}" > "${notes_file}"
+          gh release create "v${VERSION}" \
+            --target "${SOURCE_SHA}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            --notes-file "${notes_file}"

--- a/.github/workflows/build-mcp-image.yml
+++ b/.github/workflows/build-mcp-image.yml
@@ -39,6 +39,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.release_action != 'dry-run' }}
     runs-on: ubuntu-24.04
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -47,15 +48,12 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          # A bot/App token is required so the generated PR starts required
-          # pull_request checks; events from github.token are suppressed.
-          token: ${{ secrets.RELEASE_PR_TOKEN }}
 
       - name: Open or update reviewed version PR
         shell: bash
         env:
           BUMP_TYPE: ${{ inputs.release_action }}
-          GH_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           branch="automation/release-${BUMP_TYPE}"
@@ -88,6 +86,8 @@ jobs:
               --title "chore: propose ${BUMP_TYPE} release ${version}" \
               --body "${body}"
           fi
+
+          .github/scripts/dispatch-required-pr-checks.sh "${branch}"
 
           {
             echo "### Reviewed release proposal"

--- a/.github/workflows/embedding-unit-tests.yml
+++ b/.github/workflows/embedding-unit-tests.yml
@@ -9,15 +9,12 @@ on:
       - '.github/workflows/embedding-unit-tests.yml'
   pull_request:
     branches: [main, secure-build]
-    paths:
-      - 'embedding-generation/**'
-      - '.github/workflows/embedding-unit-tests.yml'
 
 permissions:
   contents: read
 
 jobs:
-  test:
+  embedding-unit-tests:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/embedding-unit-tests.yml
+++ b/.github/workflows/embedding-unit-tests.yml
@@ -1,6 +1,7 @@
 name: Embedding Generation Unit Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [main, secure-build]
     paths:

--- a/README.md
+++ b/README.md
@@ -467,10 +467,10 @@ embedding, ask the workflow to create a reviewed version PR:
 Manual workflow runs are dry runs: they build both architectures but cannot
 publish images, tags, or releases when `dry-run` is selected.
 
-The repository secret `RELEASE_PR_TOKEN` must contain a GitHub App or bot token
-with repository Contents and Pull requests read/write permissions. The
-generated PRs use this token so GitHub starts the required `pull_request`
-checks; PRs created with the workflow's built-in token do not trigger them.
+Generated PRs use the workflow's short-lived `GITHUB_TOKEN`. Because GitHub
+leaves `pull_request` runs created by that token awaiting manual workflow
+approval, the automation explicitly dispatches the required test workflows
+against the generated branch after opening or updating the PR.
 
 #### Publishing and Pinning the Updated Bundle
 

--- a/README.md
+++ b/README.md
@@ -434,15 +434,43 @@ the MCP release directly:
 3. The promotion branch updates both `container_images.embeddings` in
    `mcp-local/build-inputs.lock.json` and `EMBEDDINGS_IMAGE` in
    `mcp-local/Dockerfile`. It also records the embedding source commit and
-   workflow run.
-4. Review the source revision and digest change before merging.
-5. Merging the promotion PR to `main` triggers a minor MCP release.
-   Merely generating an embedding candidate does not release or alter the MCP
-   image.
+   workflow run and proposes the next minor version in `mcp-local/server.json`.
+4. Review the source revision, digest, and proposed version before merging.
+5. Merge the approved promotion PR to publish the MCP release using that exact
+   embedding digest and version.
 
 The promotion workflow never merges its own PR. This preserves the reviewed,
 checked-in digest as the release boundary and keeps MCP releases independent
 from unsuccessful or unwanted embedding candidates.
+
+#### Creating a Reviewed MCP Release
+
+Production releases are initiated only by a reviewed PR that updates
+`mcp-local/server.json` on `main`. Embedding promotion PRs make this update
+automatically as a minor release. For a release that does not promote a new
+embedding, ask the workflow to create a reviewed version PR:
+
+1. Start **Build MCP Image** manually and select `hotfix`, `minor`, or `major`.
+   From the CLI, for example:
+
+   ```bash
+   gh workflow run build-mcp-image.yml -f release_action=hotfix
+   ```
+
+2. The workflow opens or updates a version PR with the matching semantic
+   version change in `mcp-local/server.json`.
+3. Allow the required status checks and security-team review to complete.
+4. Merge the approved PR. **Build MCP Image** validates the version, builds the
+   exact merge commit for AMD64 and Arm64, publishes the version and `latest`
+   tags, and creates the matching `vX.Y.Z` Git tag and GitHub Release.
+
+Manual workflow runs are dry runs: they build both architectures but cannot
+publish images, tags, or releases when `dry-run` is selected.
+
+The repository secret `RELEASE_PR_TOKEN` must contain a GitHub App or bot token
+with repository Contents and Pull requests read/write permissions. The
+generated PRs use this token so GitHub starts the required `pull_request`
+checks; PRs created with the workflow's built-in token do not trigger them.
 
 #### Publishing and Pinning the Updated Bundle
 

--- a/embedding-generation/README.md
+++ b/embedding-generation/README.md
@@ -43,12 +43,16 @@ to consume the newest registry artifact automatically. To promote a candidate:
    09:00 UTC, or start it manually for an out-of-band update.
 2. After publishing the vector store, the workflow opens or updates the
    `automation/pin-embedding-vectorstore` PR with the immutable digest in both
-   `mcp-local/build-inputs.lock.json` and `mcp-local/Dockerfile`.
-3. Review the source revision and image digest.
-4. Merge the PR to trigger the minor MCP release.
+   `mcp-local/build-inputs.lock.json` and `mcp-local/Dockerfile`, along with the
+   next minor version in `mcp-local/server.json`.
+3. Review the source revision, image digest, and proposed version.
+4. Merge the approved PR to publish the MCP release using that exact embedding
+   digest and version.
 
 The workflow does not merge the promotion PR. A candidate can therefore be
 generated, evaluated, and rejected without changing the released MCP image.
+For a major or hotfix release, run **Build MCP Image** manually with the
+corresponding release action; it opens a separate reviewed version PR.
 
 ## Add Documents
 

--- a/mcp-local/tests/test_build_inputs.py
+++ b/mcp-local/tests/test_build_inputs.py
@@ -19,6 +19,7 @@ STAGE_INPUTS = (MCP_LOCAL / "scripts/stage-build-inputs.py").read_text()
 INPUT_DOCKERIGNORE = (MCP_LOCAL / ".dockerignore").read_text()
 ROOT_DOCKERIGNORE = (REPOSITORY / ".dockerignore").read_text()
 SERVER = (MCP_LOCAL / "server.py").read_text()
+SERVER_METADATA = json.loads((MCP_LOCAL / "server.json").read_text())
 INPUT_WORKFLOW = (
     REPOSITORY / ".github/workflows/build-mcp-inputs.yml"
 ).read_text()
@@ -182,11 +183,79 @@ def test_embedding_candidate_requires_reviewed_promotion_before_release() -> Non
     image_triggers = IMAGE_WORKFLOW.split("jobs:", maxsplit=1)[0]
     assert "workflow_run:" not in image_triggers
     assert "pull_request:" in image_triggers
-    assert "types: [closed]" in image_triggers
-    assert "automation/pin-embedding-vectorstore" in IMAGE_WORKFLOW
+    assert "types: [opened, synchronize, reopened]" in image_triggers
+    assert "push:" in image_triggers
+    assert "- mcp-local/server.json" in image_triggers
+    assert "automation/pin-embedding-vectorstore" not in IMAGE_WORKFLOW
     assert "propose-mcp-embedding-pin:" in EMBEDDING_WORKFLOW
     assert "update-mcp-embedding-pin.py" in EMBEDDING_WORKFLOW
+    assert "mcp-local/server.json" in EMBEDDING_WORKFLOW
     assert "gh pr merge" not in EMBEDDING_WORKFLOW
+
+
+def test_release_uses_reviewed_server_version_without_self_merging() -> None:
+    assert "Validate reviewed release version" in IMAGE_WORKFLOW
+    assert "github.event_name == 'push'" in IMAGE_WORKFLOW
+    assert 'version="$(jq -er' in IMAGE_WORKFLOW
+    assert "gh pr merge" not in IMAGE_WORKFLOW
+    assert "BUMP_BRANCH" not in IMAGE_WORKFLOW
+    assert "${IMAGE}:${VERSION}-amd64" in IMAGE_WORKFLOW
+    assert "${IMAGE}:${VERSION}-arm64" in IMAGE_WORKFLOW
+
+
+def test_manual_release_proposals_support_all_release_types() -> None:
+    assert "propose-version:" in IMAGE_WORKFLOW
+    assert "- hotfix" in IMAGE_WORKFLOW
+    assert "- minor" in IMAGE_WORKFLOW
+    assert "- major" in IMAGE_WORKFLOW
+    assert "bump_mcp_version.py" in IMAGE_WORKFLOW
+    assert "gh pr create" in IMAGE_WORKFLOW
+    assert "gh pr merge" not in IMAGE_WORKFLOW
+
+
+def test_version_bump_script_supports_all_release_types() -> None:
+    script = REPOSITORY / ".github/scripts/bump_mcp_version.py"
+    major, minor, patch = map(int, SERVER_METADATA["version"].split("."))
+    for bump_type, expected_version in (
+        ("major", f"{major + 1}.0.0"),
+        ("minor", f"{major}.{minor + 1}.0"),
+        ("hotfix", f"{major}.{minor}.{patch + 1}"),
+    ):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            server_file = Path(temporary_directory) / "server.json"
+            server_file.write_text(
+                (MCP_LOCAL / "server.json").read_text(), encoding="utf-8"
+            )
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(script),
+                    "--bump-type",
+                    bump_type,
+                    "--server-file",
+                    str(server_file),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            updated_server = json.loads(server_file.read_text())
+            assert updated_server["version"] == expected_version
+            assert any(
+                package.get("identifier")
+                == f"docker.io/armlimited/arm-mcp:{expected_version}"
+                for package in updated_server["packages"]
+            )
+
+
+def test_server_metadata_uses_its_version_for_the_release_image() -> None:
+    version = SERVER_METADATA["version"]
+    assert re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version)
+    assert any(
+        package.get("registryType") == "oci"
+        and package.get("identifier") == f"docker.io/armlimited/arm-mcp:{version}"
+        for package in SERVER_METADATA["packages"]
+    )
 
 
 def test_embedding_pin_updater_keeps_manifest_and_dockerfile_in_sync() -> None:
@@ -201,11 +270,15 @@ def test_embedding_pin_updater_keeps_manifest_and_dockerfile_in_sync() -> None:
         temporary = Path(temporary_directory)
         lock_file = temporary / "build-inputs.lock.json"
         dockerfile = temporary / "Dockerfile"
+        server_file = temporary / "server.json"
         lock_file.write_text(
             (MCP_LOCAL / "build-inputs.lock.json").read_text(), encoding="utf-8"
         )
         dockerfile.write_text(
             (MCP_LOCAL / "Dockerfile").read_text(), encoding="utf-8"
+        )
+        server_file.write_text(
+            (MCP_LOCAL / "server.json").read_text(), encoding="utf-8"
         )
         subprocess.run(
             [
@@ -221,6 +294,8 @@ def test_embedding_pin_updater_keeps_manifest_and_dockerfile_in_sync() -> None:
                 str(lock_file),
                 "--dockerfile",
                 str(dockerfile),
+                "--server-file",
+                str(server_file),
             ],
             check=True,
         )
@@ -231,6 +306,17 @@ def test_embedding_pin_updater_keeps_manifest_and_dockerfile_in_sync() -> None:
         assert embeddings["source_revision"] == new_revision
         assert embeddings["workflow_run"] == "123456"
         assert f"ARG EMBEDDINGS_IMAGE={new_reference}" in dockerfile.read_text()
+        updated_server = json.loads(server_file.read_text())
+        current_major, current_minor, _ = map(
+            int, SERVER_METADATA["version"].split(".")
+        )
+        expected_version = f"{current_major}.{current_minor + 1}.0"
+        assert updated_server["version"] == expected_version
+        assert any(
+            package.get("identifier")
+            == f"docker.io/armlimited/arm-mcp:{expected_version}"
+            for package in updated_server["packages"]
+        )
 
 
 def test_build_input_bundle_is_immutable_and_auditable() -> None:

--- a/mcp-local/tests/test_build_inputs.py
+++ b/mcp-local/tests/test_build_inputs.py
@@ -190,7 +190,6 @@ def test_embedding_candidate_requires_reviewed_promotion_before_release() -> Non
     image_triggers = IMAGE_WORKFLOW.split("jobs:", maxsplit=1)[0]
     assert "workflow_run:" not in image_triggers
     assert "pull_request:" in image_triggers
-    assert "types: [opened, synchronize, reopened]" in image_triggers
     assert "push:" in image_triggers
     assert "- mcp-local/server.json" in image_triggers
     assert "automation/pin-embedding-vectorstore" not in IMAGE_WORKFLOW

--- a/mcp-local/tests/test_build_inputs.py
+++ b/mcp-local/tests/test_build_inputs.py
@@ -27,6 +27,9 @@ EMBEDDING_WORKFLOW = (
     REPOSITORY / ".github/workflows/build-embeddings.yml"
 ).read_text()
 IMAGE_WORKFLOW = (REPOSITORY / ".github/workflows/build-mcp-image.yml").read_text()
+REQUIRED_CHECK_DISPATCH = (
+    REPOSITORY / ".github/scripts/dispatch-required-pr-checks.sh"
+).read_text()
 INTEGRATION_WORKFLOW = (
     REPOSITORY / ".github/workflows/integration-tests.yml"
 ).read_text()
@@ -211,6 +214,21 @@ def test_manual_release_proposals_support_all_release_types() -> None:
     assert "bump_mcp_version.py" in IMAGE_WORKFLOW
     assert "gh pr create" in IMAGE_WORKFLOW
     assert "gh pr merge" not in IMAGE_WORKFLOW
+    assert "RELEASE_PR_TOKEN" not in IMAGE_WORKFLOW
+    assert "dispatch-required-pr-checks.sh" in IMAGE_WORKFLOW
+
+
+def test_generated_prs_dispatch_required_checks_without_an_external_token() -> None:
+    assert "RELEASE_PR_TOKEN" not in EMBEDDING_WORKFLOW
+    assert "actions: write" in IMAGE_WORKFLOW
+    assert "actions: write" in EMBEDDING_WORKFLOW
+    assert "dispatch-required-pr-checks.sh" in EMBEDDING_WORKFLOW
+    for workflow in (
+        "integration-tests.yml",
+        "embedding-unit-tests.yml",
+        "scorecard.yml",
+    ):
+        assert workflow in REQUIRED_CHECK_DISPATCH
 
 
 def test_version_bump_script_supports_all_release_types() -> None:


### PR DESCRIPTION
- Added CODEOWNERS: release/supply-chain files require @arm/mcp-security-team; general files remain unrestricted.
- Reworked releases around reviewed version PRs; removed self-merging, bump branches, date tags, and rerun/race logic.
- Embedding promotion PRs now include the next minor version.
- Manual workflow supports reviewed major, minor, and hotfix PRs.
- Merged version PRs build the exact commit, publish multi-architecture images, and create matching tags/releases.
- Added reusable version-bump tooling, documentation, and tests.