### PR TITLE
Trigger input bundle updates

### DIFF
--- a/.github/scripts/propose-pin-pr.sh
+++ b/.github/scripts/propose-pin-pr.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for required in \
+  PROMOTION_BRANCH \
+  COMMIT_MESSAGE \
+  PR_TITLE \
+  PR_BODY \
+  SUMMARY_TITLE \
+  CANDIDATE \
+  GH_TOKEN; do
+  if [ -z "${!required:-}" ]; then
+    echo "::error::${required} is required to propose a pin update."
+    exit 1
+  fi
+done
+if [ "$#" -eq 0 ]; then
+  echo "::error::At least one generated pin file must be selected."
+  exit 1
+fi
+
+files=("$@")
+git checkout -B "${PROMOTION_BRANCH}"
+if git diff --quiet -- "${files[@]}"; then
+  echo "The generated artifact already matches the checked-in pin." \
+    >> "${GITHUB_STEP_SUMMARY}"
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add -- "${files[@]}"
+git commit -m "${COMMIT_MESSAGE}"
+
+git fetch origin \
+  "${PROMOTION_BRANCH}:refs/remotes/origin/${PROMOTION_BRANCH}" || true
+git push --force-with-lease origin "HEAD:refs/heads/${PROMOTION_BRANCH}"
+
+body_file="${RUNNER_TEMP}/pin-promotion-${GITHUB_RUN_ID}.md"
+printf '%s\n' "${PR_BODY}" > "${body_file}"
+
+pr_url="$(gh pr list \
+  --base main \
+  --head "${PROMOTION_BRANCH}" \
+  --state open \
+  --json url \
+  --jq '.[0].url // empty')"
+if [ -z "${pr_url}" ]; then
+  pr_url="$(gh pr create \
+    --base main \
+    --head "${PROMOTION_BRANCH}" \
+    --title "${PR_TITLE}" \
+    --body-file "${body_file}")"
+else
+  gh pr edit "${pr_url}" \
+    --title "${PR_TITLE}" \
+    --body-file "${body_file}"
+fi
+
+.github/scripts/dispatch-required-pr-checks.sh "${PROMOTION_BRANCH}"
+
+{
+  echo "### ${SUMMARY_TITLE}"
+  echo ""
+  echo "- Pull request: ${pr_url}"
+  echo "- Candidate: \`${CANDIDATE}\`"
+  if [ -n "${SUMMARY_DETAILS:-}" ]; then
+    printf '%s\n' "${SUMMARY_DETAILS}"
+  fi
+} >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/scripts/update-embedding-toolchain-pin.py
+++ b/.github/scripts/update-embedding-toolchain-pin.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Update the immutable embedding toolchain input used by the pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+DEFAULT_LOCK = REPOSITORY / "embedding-generation" / "pipeline-inputs.lock.json"
+REFERENCE_PATTERN = re.compile(
+    r"^ghcr\.io/[A-Za-z0-9_.-]+/mcp-embedding-generator@sha256:[0-9a-f]{64}$"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reference", required=True)
+    parser.add_argument("--lock-file", type=Path, default=DEFAULT_LOCK)
+    return parser.parse_args()
+
+
+def update_pin(*, reference: str, lock_file: Path) -> None:
+    if not REFERENCE_PATTERN.fullmatch(reference):
+        raise ValueError(
+            f"invalid immutable embedding toolchain reference: {reference}"
+        )
+
+    lock = json.loads(lock_file.read_text(encoding="utf-8"))
+    if set(lock) != {"generator_image", "intrinsic_chunks_image"}:
+        raise ValueError("pipeline input lock does not contain the expected keys")
+
+    lock["generator_image"] = reference
+    lock_file.write_text(json.dumps(lock, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    update_pin(reference=args.reference, lock_file=args.lock_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/update-mcp-input-pin.py
+++ b/.github/scripts/update-mcp-input-pin.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Keep the checked-in MCP build-input image pins synchronized."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+DEFAULT_LOCK = REPOSITORY / "mcp-local" / "build-inputs.lock.json"
+DEFAULT_DOCKERFILE = REPOSITORY / "mcp-local" / "Dockerfile"
+REFERENCE_PATTERN = re.compile(
+    r"^ghcr\.io/[A-Za-z0-9_.-]+/mcp-build-inputs@sha256:[0-9a-f]{64}$"
+)
+REVISION_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reference", required=True)
+    parser.add_argument("--amd64-reference", required=True)
+    parser.add_argument("--arm64-reference", required=True)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--workflow-run", required=True)
+    parser.add_argument("--lock-file", type=Path, default=DEFAULT_LOCK)
+    parser.add_argument("--dockerfile", type=Path, default=DEFAULT_DOCKERFILE)
+    return parser.parse_args()
+
+
+def update_pin(
+    *,
+    reference: str,
+    amd64_reference: str,
+    arm64_reference: str,
+    source_revision: str,
+    workflow_run: str,
+    lock_file: Path,
+    dockerfile: Path,
+) -> None:
+    references = (reference, amd64_reference, arm64_reference)
+    if not all(REFERENCE_PATTERN.fullmatch(value) for value in references):
+        raise ValueError("invalid immutable MCP build-input reference")
+    if len(set(references)) != len(references):
+        raise ValueError("index and architecture references must be distinct")
+    if not REVISION_PATTERN.fullmatch(source_revision):
+        raise ValueError(f"invalid source revision: {source_revision}")
+    if not workflow_run.isdigit():
+        raise ValueError(f"invalid workflow run ID: {workflow_run}")
+
+    lock = json.loads(lock_file.read_text(encoding="utf-8"))
+    build_inputs = lock["container_images"]["mcp_build_inputs"]
+    if set(build_inputs["manifests"]) != {"amd64", "arm64"}:
+        raise ValueError("MCP build-input manifest does not cover amd64 and arm64")
+
+    previous_reference = build_inputs["reference"]
+    previous_arg = f"ARG MCP_BUILD_INPUTS_IMAGE={previous_reference}"
+    dockerfile_text = dockerfile.read_text(encoding="utf-8")
+    if dockerfile_text.count(previous_arg) != 1:
+        raise RuntimeError(
+            "Dockerfile MCP_BUILD_INPUTS_IMAGE does not match the checked-in manifest"
+        )
+
+    # Re-running the same source revision can reproduce the exact image index.
+    # Keep the reviewed provenance in that case instead of opening a metadata-only
+    # promotion PR for a new workflow run.
+    if reference == previous_reference:
+        return
+
+    build_inputs["reference"] = reference
+    build_inputs["manifests"] = {
+        "amd64": amd64_reference,
+        "arm64": arm64_reference,
+    }
+    build_inputs["source_revision"] = source_revision
+    build_inputs["workflow_run"] = workflow_run
+    lock_file.write_text(json.dumps(lock, indent=2) + "\n", encoding="utf-8")
+    dockerfile.write_text(
+        dockerfile_text.replace(
+            previous_arg, f"ARG MCP_BUILD_INPUTS_IMAGE={reference}"
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    update_pin(
+        reference=args.reference,
+        amd64_reference=args.amd64_reference,
+        arm64_reference=args.arm64_reference,
+        source_revision=args.source_revision,
+        workflow_run=args.workflow_run,
+        lock_file=args.lock_file,
+        dockerfile=args.dockerfile,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build-embedding-toolchain.yml
+++ b/.github/workflows/build-embedding-toolchain.yml
@@ -121,7 +121,7 @@ jobs:
           COMMIT_MESSAGE: "chore: update embedding toolchain input"
           PR_TITLE: "chore: update embedding toolchain input"
           PR_BODY: |
-            Updates the immutable embedding toolchain input after its Python requirements changed.
+            Updates the immutable embedding toolchain input after its source inputs changed.
 
             - Source revision: `${{ github.sha }}`
             - Workflow run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/build-embedding-toolchain.yml
+++ b/.github/workflows/build-embedding-toolchain.yml
@@ -1,6 +1,11 @@
 name: Build Embedding Toolchain Image
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - embedding-generation/pyproject.toml
+      - embedding-generation/uv.lock
   workflow_dispatch:
 
 permissions:
@@ -10,6 +15,10 @@ env:
   IMAGE: ghcr.io/${{ github.repository_owner }}/mcp-embedding-generator
   PACKAGE_NAME: mcp-embedding-generator
 
+concurrency:
+  group: embedding-toolchain-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-toolchain:
     runs-on: ubuntu-24.04-arm
@@ -17,6 +26,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -66,3 +77,48 @@ jobs:
             echo "- Tag: \`${TAG}\`"
             echo "- Immutable reference: \`${IMAGE}@${DIGEST}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
+
+  propose-toolchain-pin:
+    needs: build-toolchain
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    env:
+      PROMOTION_BRANCH: automation/pin-embedding-generator
+      TOOLCHAIN_REFERENCE: ghcr.io/${{ github.repository_owner }}/mcp-embedding-generator@${{ needs.build-toolchain.outputs.image-digest }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Update checked-in toolchain pin
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/update-embedding-toolchain-pin.py \
+            --reference "${TOOLCHAIN_REFERENCE}"
+
+      - name: Propose toolchain pin for review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_MESSAGE: "chore: update embedding toolchain input"
+          PR_TITLE: "chore: update embedding toolchain input"
+          PR_BODY: |
+            Updates the immutable embedding toolchain input after its Python requirements changed.
+
+            - Source revision: `${{ github.sha }}`
+            - Workflow run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            - Candidate: `${{ env.TOOLCHAIN_REFERENCE }}`
+
+            Merging this PR makes subsequent embedding-generation runs use the rebuilt toolchain.
+          SUMMARY_TITLE: Embedding toolchain promotion
+          CANDIDATE: ${{ env.TOOLCHAIN_REFERENCE }}
+        run: >-
+          bash .github/scripts/propose-pin-pr.sh
+          embedding-generation/pipeline-inputs.lock.json

--- a/.github/workflows/build-embedding-toolchain.yml
+++ b/.github/workflows/build-embedding-toolchain.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [main]
     paths:
+      - embedding-generation/.dockerignore
+      - embedding-generation/.python-version
+      - embedding-generation/Dockerfile.toolchain
+      - embedding-generation/acquire-model.py
+      - embedding-generation/document_chunking.py
+      - embedding-generation/embedding-model.lock.json
+      - embedding-generation/generate-chunks.py
+      - embedding-generation/local_vectorstore_creation.py
       - embedding-generation/pyproject.toml
       - embedding-generation/uv.lock
   workflow_dispatch:
@@ -96,6 +104,9 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+
+      - name: Verify main has not advanced
+        run: test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
 
       - name: Update checked-in toolchain pin
         shell: bash

--- a/.github/workflows/build-embeddings.yml
+++ b/.github/workflows/build-embeddings.yml
@@ -243,6 +243,9 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - name: Verify main has not advanced
+        run: test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+
       - name: Update checked-in embedding pin and release version
         id: update
         shell: bash

--- a/.github/workflows/build-embeddings.yml
+++ b/.github/workflows/build-embeddings.yml
@@ -248,7 +248,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git checkout -B "${PROMOTION_BRANCH}"
           python3 .github/scripts/update-mcp-embedding-pin.py \
             --reference "${EMBEDDINGS_REFERENCE}" \
             --source-revision "${GITHUB_SHA}" \
@@ -257,68 +256,30 @@ jobs:
           release_version="$(jq -er '.version' mcp-local/server.json)"
           echo "release_version=${release_version}" >> "${GITHUB_OUTPUT}"
 
-          if git diff --quiet -- mcp-local/Dockerfile mcp-local/build-inputs.lock.json mcp-local/server.json; then
-            echo "changed=false" >> "${GITHUB_OUTPUT}"
-            echo "The generated vector store already matches the checked-in MCP pin." >> "${GITHUB_STEP_SUMMARY}"
-          else
-            echo "changed=true" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Push promotion branch and open or update PR
-        if: ${{ steps.update.outputs.changed == 'true' }}
+      - name: Propose embedding pin for review
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ steps.update.outputs.release_version }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add mcp-local/Dockerfile mcp-local/build-inputs.lock.json mcp-local/server.json
-          git commit -m "chore: promote embeddings for ${RELEASE_VERSION}"
+          COMMIT_MESSAGE: "chore: promote embeddings for ${{ steps.update.outputs.release_version }}"
+          PR_TITLE: "chore: promote embeddings for ${{ steps.update.outputs.release_version }}"
+          PR_BODY: |
+            Promotes the immutable embedding vector store produced by:
 
-          git fetch origin "${PROMOTION_BRANCH}:refs/remotes/origin/${PROMOTION_BRANCH}" || true
-          git push --force-with-lease origin "HEAD:refs/heads/${PROMOTION_BRANCH}"
+            - Source revision: `${{ github.sha }}`
+            - Workflow run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            - Candidate: `${{ env.EMBEDDINGS_REFERENCE }}`
+            - Proposed MCP version: `${{ steps.update.outputs.release_version }}`
 
-          body_file="${RUNNER_TEMP}/embedding-promotion.md"
-          cat > "${body_file}" <<EOF
-          Promotes the immutable embedding vector store produced by:
+            This PR updates the checked-in build-input manifest, Dockerfile default, and MCP release version. Merging the reviewed PR releases an MCP image using this exact digest.
+          SUMMARY_TITLE: MCP embedding promotion
+          CANDIDATE: ${{ env.EMBEDDINGS_REFERENCE }}
+          SUMMARY_DETAILS: |
+            - Proposed MCP version: `${{ steps.update.outputs.release_version }}`
+        run: >-
+          bash .github/scripts/propose-pin-pr.sh
+          mcp-local/Dockerfile
+          mcp-local/build-inputs.lock.json
+          mcp-local/server.json
 
-          - Source revision: \`${GITHUB_SHA}\`
-          - Workflow run: [${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
-          - Candidate: \`${EMBEDDINGS_REFERENCE}\`
-          - Proposed MCP version: \`${RELEASE_VERSION}\`
-
-          This PR updates the checked-in build-input manifest, Dockerfile default, and MCP release version. Merging the reviewed PR releases an MCP image using this exact digest.
-          EOF
-
-          pr_url="$(gh pr list \
-            --base main \
-            --head "${PROMOTION_BRANCH}" \
-            --state open \
-            --json url \
-            --jq '.[0].url // empty')"
-          if [ -z "${pr_url}" ]; then
-            pr_url="$(gh pr create \
-              --base main \
-              --head "${PROMOTION_BRANCH}" \
-              --title "chore: promote embeddings for ${RELEASE_VERSION}" \
-              --body-file "${body_file}")"
-          else
-            gh pr edit "${pr_url}" \
-              --title "chore: promote embeddings for ${RELEASE_VERSION}" \
-              --body-file "${body_file}"
-          fi
-
-          .github/scripts/dispatch-required-pr-checks.sh "${PROMOTION_BRANCH}"
-
-          {
-            echo "### MCP embedding promotion"
-            echo ""
-            echo "- Pull request: ${pr_url}"
-            echo "- Candidate: \`${EMBEDDINGS_REFERENCE}\`"
-            echo "- Proposed MCP version: \`${RELEASE_VERSION}\`"
-          } >> "${GITHUB_STEP_SUMMARY}"
   verify-vectorstore-provenance:
     needs: generate-and-publish-vectorstore
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-mcp-inputs.yml
+++ b/.github/workflows/build-mcp-inputs.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [main]
     paths:
+      - mcp-local/.dockerignore
+      - mcp-local/.python-version
+      - mcp-local/Dockerfile.inputs
       - mcp-local/pyproject.toml
+      - mcp-local/scripts/stage-build-inputs.py
       - mcp-local/uv.lock
   workflow_dispatch:
 
@@ -211,6 +215,9 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+
+      - name: Verify main has not advanced
+        run: test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
 
       - name: Update checked-in MCP input pin
         shell: bash

--- a/.github/workflows/build-mcp-inputs.yml
+++ b/.github/workflows/build-mcp-inputs.yml
@@ -191,8 +191,6 @@ jobs:
             echo "- Tag: \`${IMAGE}:${PUBLICATION_TAG}\`"
             echo "- Digest: \`${digest}\`"
             echo "- MCP build input: \`${IMAGE}@${digest}\`"
-            echo ""
-            echo "Record this digest in \`mcp-local/build-inputs.lock.json\` before the release workflow consumes it."
           } >> "${GITHUB_STEP_SUMMARY}"
 
   propose-input-pin:

--- a/.github/workflows/build-mcp-inputs.yml
+++ b/.github/workflows/build-mcp-inputs.yml
@@ -1,6 +1,11 @@
 name: Build MCP Input Bundle
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - mcp-local/pyproject.toml
+      - mcp-local/uv.lock
   workflow_dispatch:
 
 permissions: read-all
@@ -9,6 +14,10 @@ env:
   IMAGE: ghcr.io/${{ github.repository_owner }}/mcp-build-inputs
   PACKAGE_NAME: mcp-build-inputs
   PUBLICATION_TAG: git-${{ github.sha }}-run-${{ github.run_id }}-${{ github.run_attempt }}
+
+concurrency:
+  group: mcp-input-bundle-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   acquire-and-publish-architecture:
@@ -103,6 +112,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image-reference: ${{ steps.pin.outputs.image-reference }}
+      amd64-reference: ${{ steps.pin.outputs.amd64-reference }}
+      arm64-reference: ${{ steps.pin.outputs.arm64-reference }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -131,6 +144,7 @@ jobs:
         run: bash .github/scripts/verify-ghcr-package-private.sh "${PACKAGE_NAME}"
 
       - name: Record immutable input reference
+        id: pin
         shell: bash
         run: |
           set -euo pipefail
@@ -142,6 +156,31 @@ jobs:
             exit 1
           fi
 
+          raw_manifest="$(docker buildx imagetools inspect \
+            "${IMAGE}:${PUBLICATION_TAG}" --raw)"
+          amd64_digest="$(jq -er '
+            .manifests[] |
+            select(.platform.os == "linux" and .platform.architecture == "amd64") |
+            .digest
+          ' <<<"${raw_manifest}")"
+          arm64_digest="$(jq -er '
+            .manifests[] |
+            select(.platform.os == "linux" and .platform.architecture == "arm64") |
+            .digest
+          ' <<<"${raw_manifest}")"
+          for platform_digest in "${amd64_digest}" "${arm64_digest}"; do
+            if [[ ! "${platform_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::Published index contains an invalid platform digest."
+              exit 1
+            fi
+          done
+
+          {
+            echo "image-reference=${IMAGE}@${digest}"
+            echo "amd64-reference=${IMAGE}@${amd64_digest}"
+            echo "arm64-reference=${IMAGE}@${arm64_digest}"
+          } >> "${GITHUB_OUTPUT}"
+
           {
             echo "### Immutable MCP build-input artifact"
             echo ""
@@ -151,3 +190,57 @@ jobs:
             echo ""
             echo "Record this digest in \`mcp-local/build-inputs.lock.json\` before the release workflow consumes it."
           } >> "${GITHUB_STEP_SUMMARY}"
+
+  propose-input-pin:
+    needs: publish-index
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    env:
+      PROMOTION_BRANCH: automation/pin-mcp-build-inputs
+      INPUT_REFERENCE: ${{ needs.publish-index.outputs.image-reference }}
+      AMD64_REFERENCE: ${{ needs.publish-index.outputs.amd64-reference }}
+      ARM64_REFERENCE: ${{ needs.publish-index.outputs.arm64-reference }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Update checked-in MCP input pin
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/update-mcp-input-pin.py \
+            --reference "${INPUT_REFERENCE}" \
+            --amd64-reference "${AMD64_REFERENCE}" \
+            --arm64-reference "${ARM64_REFERENCE}" \
+            --source-revision "${GITHUB_SHA}" \
+            --workflow-run "${GITHUB_RUN_ID}"
+
+      - name: Propose MCP input pin for review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_MESSAGE: "chore: update MCP build-input bundle"
+          PR_TITLE: "chore: update MCP build-input bundle"
+          PR_BODY: |
+            Updates the immutable MCP build-input bundle after its Python requirements changed.
+
+            - Source revision: `${{ github.sha }}`
+            - Workflow run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            - Candidate: `${{ env.INPUT_REFERENCE }}`
+            - AMD64 manifest: `${{ env.AMD64_REFERENCE }}`
+            - Arm64 manifest: `${{ env.ARM64_REFERENCE }}`
+
+            This PR keeps the build-input manifest and Dockerfile default synchronized.
+          SUMMARY_TITLE: MCP build-input promotion
+          CANDIDATE: ${{ env.INPUT_REFERENCE }}
+        run: >-
+          bash .github/scripts/propose-pin-pr.sh
+          mcp-local/Dockerfile
+          mcp-local/build-inputs.lock.json

--- a/.github/workflows/build-mcp-inputs.yml
+++ b/.github/workflows/build-mcp-inputs.yml
@@ -236,7 +236,7 @@ jobs:
           COMMIT_MESSAGE: "chore: update MCP build-input bundle"
           PR_TITLE: "chore: update MCP build-input bundle"
           PR_BODY: |
-            Updates the immutable MCP build-input bundle after its Python requirements changed.
+            Updates the immutable MCP build-input bundle after its source inputs changed.
 
             - Source revision: `${{ github.sha }}`
             - Workflow run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/README.md
+++ b/README.md
@@ -487,10 +487,12 @@ against the generated branch after opening or updating the PR.
 
 #### Publishing and Pinning the Updated Bundle
 
-Python requirement changes use this automatic publication process:
+Changes to the Python requirements, Python version, acquisition script, input
+Dockerfile, or its Docker context configuration use this automatic publication
+process:
 
-1. Merge the reviewed `mcp-local/pyproject.toml` and `mcp-local/uv.lock`
-   changes to `main`.
+1. Merge the reviewed changes to the automatically watched bundle inputs on
+   `main`.
 2. The workflow builds both architectures, publishes their index, and opens or
    updates `automation/pin-mcp-build-inputs`.
 3. Review the immutable index digest, per-architecture manifest digests, source
@@ -503,14 +505,29 @@ Python requirement changes use this automatic publication process:
    synchronized. Release and integration builds pull this reviewed digest and
    never invoke `stage-build-inputs.py`.
 
-For changes to other bundle inputs, or to test a branch without opening a
-promotion PR, start the workflow manually:
+`mcp-local/build-inputs.lock.json` is deliberately excluded from the automatic
+path trigger. The file contains both acquisition inputs and the published
+bundle's own digest, and it is copied into the bundle as audit metadata. If a
+pin-only update triggered another build, that metadata change would produce a
+new digest and an endless sequence of promotion PRs.
+
+After merging a reviewed change to another acquisition input stored in that
+file, such as the Ubuntu snapshot or package closure, Performix artifact, or
+migrate-ease revision, run the workflow manually on `main`:
+
+```bash
+gh workflow run build-mcp-inputs.yml --ref main
+```
+
+The `main` run publishes the replacement bundle and opens or updates
+`automation/pin-mcp-build-inputs`. To test a branch without opening a promotion
+PR, run the same workflow against that branch instead:
 
 ```bash
 gh workflow run build-mcp-inputs.yml --ref YOUR_BRANCH
 ```
 
-Only runs on `main` open a promotion PR. A manual branch run publishes a
+Only runs on `main` open a promotion PR. A manual non-`main` run publishes a
 candidate for inspection without changing checked-in pins.
 
 The publication workflow also creates a tag containing the source commit,

--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ The final MCP image build does not resolve or download Python packages, Ubuntu
 packages, Performix, or migrate-ease. Those inputs are acquired separately by
 the **Build MCP Input Bundle** workflow and published as a private,
 multi-architecture OCI image at `ghcr.io/arm/mcp-build-inputs`. The workflow
-runs automatically when the MCP Python dependency manifest or uv lock changes
-on `main`, and it can also be started manually.
+runs automatically on `main` when its watched bundle inputs change, and it can
+also be started manually.
 
 The acquisition workflow runs natively on AMD64 and Arm64. For each
 architecture it:

--- a/README.md
+++ b/README.md
@@ -219,8 +219,10 @@ their contents before sharing them.
 
 The final MCP image build does not resolve or download Python packages, Ubuntu
 packages, Performix, or migrate-ease. Those inputs are acquired separately by
-the manually triggered **Build MCP Input Bundle** workflow and published as a
-private, multi-architecture OCI image at `ghcr.io/arm/mcp-build-inputs`.
+the **Build MCP Input Bundle** workflow and published as a private,
+multi-architecture OCI image at `ghcr.io/arm/mcp-build-inputs`. The workflow
+runs automatically when the MCP Python dependency manifest or uv lock changes
+on `main`, and it can also be started manually.
 
 The acquisition workflow runs natively on AMD64 and Arm64. For each
 architecture it:
@@ -370,7 +372,18 @@ Review and commit the `pyproject.toml` and `uv.lock` changes. During input
 acquisition, pinned uv exports a pip-compatible hashed lock from `uv.lock`.
 That generated file is used to download the AMD64 and Arm64 wheelhouses and is
 preserved as `metadata/requirements.lock` in the immutable GHCR input artifact;
-it is not checked into the repository.
+it is not checked into the repository. Once the dependency change reaches
+`main`, the input workflow publishes a replacement bundle and opens or updates
+`automation/pin-mcp-build-inputs` with the new index and platform digests.
+
+The dependency PR and generated pin PR validate different boundaries. On the
+dependency PR, Python unit tests use the proposed `uv.lock`, while Docker
+integration tests continue to use the currently approved input bundle. After
+the dependency change merges, the generated pin PR updates the Dockerfile to
+the replacement bundle, so its Docker integration tests exercise the new
+dependencies before that bundle is approved. A dependency change therefore
+does not affect MCP image builds until its follow-up pin PR passes review and
+is merged.
 
 #### Updating the Python Interpreter
 
@@ -474,26 +487,31 @@ against the generated branch after opening or updating the PR.
 
 #### Publishing and Pinning the Updated Bundle
 
-After updating any source lock, use the same common publication process:
+Python requirement changes use this automatic publication process:
 
-1. Commit and push the updated source locks to a branch.
-2. Start the workflow on that branch:
+1. Merge the reviewed `mcp-local/pyproject.toml` and `mcp-local/uv.lock`
+   changes to `main`.
+2. The workflow builds both architectures, publishes their index, and opens or
+   updates `automation/pin-mcp-build-inputs`.
+3. Review the immutable index digest, per-architecture manifest digests, source
+   commit, and workflow run recorded by the promotion PR.
+4. Let the required integration checks run against the replacement bundle on
+   the promotion PR. These checks are dispatched automatically because PRs
+   opened with `GITHUB_TOKEN` do not trigger them directly.
+5. Merge the promotion PR after review and successful checks. This keeps
+   `mcp-local/build-inputs.lock.json` and the `MCP_BUILD_INPUTS_IMAGE` default
+   synchronized. Release and integration builds pull this reviewed digest and
+   never invoke `stage-build-inputs.py`.
 
-   ```bash
-   gh workflow run build-mcp-inputs.yml --ref YOUR_BRANCH
-   ```
+For changes to other bundle inputs, or to test a branch without opening a
+promotion PR, start the workflow manually:
 
-3. Confirm that both
-   native architecture jobs pass and that the workflow reports the package as
-   private.
-4. Inspect the published index, then copy its immutable index digest,
-   per-architecture manifest digests, source commit, and workflow run into the
-   `container_images.mcp_build_inputs` entry in
-   `mcp-local/build-inputs.lock.json`.
-5. Update the `MCP_BUILD_INPUTS_IMAGE` default in `mcp-local/Dockerfile` to the
-   same index digest and submit that pin as a reviewed follow-up change.
-6. Run the integration workflow. The release and integration builds must pull
-   the digest and must never invoke `stage-build-inputs.py`.
+```bash
+gh workflow run build-mcp-inputs.yml --ref YOUR_BRANCH
+```
+
+Only runs on `main` open a promotion PR. A manual branch run publishes a
+candidate for inspection without changing checked-in pins.
 
 The publication workflow also creates a tag containing the source commit,
 workflow run ID, and attempt. That tag is only a discovery aid; production

--- a/embedding-generation/README.md
+++ b/embedding-generation/README.md
@@ -25,10 +25,12 @@ The toolchain image:
 4. Copies the locked environment, local model, and generation scripts into the
    final image without including the `uv` package manager.
 
-When `pyproject.toml` or `uv.lock` changes on `main`, GitHub Actions rebuilds
-this image and opens or updates `automation/pin-embedding-generator`. That PR
-updates `pipeline-inputs.lock.json` to the new immutable digest. The workflow
-also supports manual branch runs, which publish an image without opening a PR.
+When a file baked into the toolchain changes on `main`, including its
+Dockerfile, Python or model locks, acquisition code, or generation scripts,
+GitHub Actions rebuilds this image and opens or updates
+`automation/pin-embedding-generator`. That PR updates
+`pipeline-inputs.lock.json` to the new immutable digest. The workflow also
+supports manual branch runs, which publish an image without opening a PR.
 
 `Dockerfile.acquire` uses this toolchain for network-enabled discovery and
 content acquisition, then publishes only the acquired chunk snapshot from a

--- a/embedding-generation/README.md
+++ b/embedding-generation/README.md
@@ -25,6 +25,11 @@ The toolchain image:
 4. Copies the locked environment, local model, and generation scripts into the
    final image without including the `uv` package manager.
 
+When `pyproject.toml` or `uv.lock` changes on `main`, GitHub Actions rebuilds
+this image and opens or updates `automation/pin-embedding-generator`. That PR
+updates `pipeline-inputs.lock.json` to the new immutable digest. The workflow
+also supports manual branch runs, which publish an image without opening a PR.
+
 `Dockerfile.acquire` uses this toolchain for network-enabled discovery and
 content acquisition, then publishes only the acquired chunk snapshot from a
 scratch stage. `Dockerfile.vectorstore` uses the same toolchain and that

--- a/mcp-local/tests/test_build_inputs.py
+++ b/mcp-local/tests/test_build_inputs.py
@@ -350,12 +350,23 @@ def test_embedding_pin_updater_keeps_manifest_and_dockerfile_in_sync() -> None:
         )
 
 
-def test_requirement_changes_rebuild_and_propose_embedding_toolchain_pin() -> None:
+def test_toolchain_input_changes_rebuild_and_propose_pin() -> None:
     workflow_triggers = TOOLCHAIN_WORKFLOW.split("jobs:", maxsplit=1)[0]
     assert "push:" in workflow_triggers
     assert "branches: [main]" in workflow_triggers
-    assert "embedding-generation/pyproject.toml" in workflow_triggers
-    assert "embedding-generation/uv.lock" in workflow_triggers
+    for source in (
+        ".dockerignore",
+        ".python-version",
+        "Dockerfile.toolchain",
+        "acquire-model.py",
+        "document_chunking.py",
+        "embedding-model.lock.json",
+        "generate-chunks.py",
+        "local_vectorstore_creation.py",
+        "pyproject.toml",
+        "uv.lock",
+    ):
+        assert f"embedding-generation/{source}" in workflow_triggers
     assert "propose-toolchain-pin:" in TOOLCHAIN_WORKFLOW
     assert "update-embedding-toolchain-pin.py" in TOOLCHAIN_WORKFLOW
     assert "automation/pin-embedding-generator" in TOOLCHAIN_WORKFLOW
@@ -438,8 +449,16 @@ def test_input_publication_is_automatic_private_and_multi_architecture() -> None
     assert "permissions: read-all" in workflow_triggers
     assert "push:" in workflow_triggers
     assert "branches: [main]" in workflow_triggers
-    assert "mcp-local/pyproject.toml" in workflow_triggers
-    assert "mcp-local/uv.lock" in workflow_triggers
+    for source in (
+        ".dockerignore",
+        ".python-version",
+        "Dockerfile.inputs",
+        "pyproject.toml",
+        "scripts/stage-build-inputs.py",
+        "uv.lock",
+    ):
+        assert f"mcp-local/{source}" in workflow_triggers
+    assert "mcp-local/build-inputs.lock.json" not in workflow_triggers
     assert "tags:" not in workflow_triggers
     assert "packages: write" in INPUT_WORKFLOW
     assert "verify-ghcr-package-private.sh" in INPUT_WORKFLOW
@@ -472,6 +491,11 @@ def test_pin_promotions_share_review_pr_mechanics() -> None:
         assert "propose-pin-pr.sh" in workflow
         assert "gh pr create" not in workflow
         assert "gh pr edit" not in workflow
+
+
+def test_pin_promotions_skip_candidates_built_from_stale_inputs() -> None:
+    for workflow in PIN_WORKFLOWS:
+        assert 'test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"' in workflow
 
 
 def test_mcp_input_pin_updater_keeps_manifest_and_dockerfile_in_sync() -> None:

--- a/mcp-local/tests/test_build_inputs.py
+++ b/mcp-local/tests/test_build_inputs.py
@@ -23,10 +23,17 @@ SERVER_METADATA = json.loads((MCP_LOCAL / "server.json").read_text())
 INPUT_WORKFLOW = (
     REPOSITORY / ".github/workflows/build-mcp-inputs.yml"
 ).read_text()
+TOOLCHAIN_WORKFLOW = (
+    REPOSITORY / ".github/workflows/build-embedding-toolchain.yml"
+).read_text()
+PIN_PROMOTION_SCRIPT = (
+    REPOSITORY / ".github/scripts/propose-pin-pr.sh"
+).read_text()
 EMBEDDING_WORKFLOW = (
     REPOSITORY / ".github/workflows/build-embeddings.yml"
 ).read_text()
 IMAGE_WORKFLOW = (REPOSITORY / ".github/workflows/build-mcp-image.yml").read_text()
+PIN_WORKFLOWS = (TOOLCHAIN_WORKFLOW, INPUT_WORKFLOW, EMBEDDING_WORKFLOW)
 REQUIRED_CHECK_DISPATCH = (
     REPOSITORY / ".github/scripts/dispatch-required-pr-checks.sh"
 ).read_text()
@@ -225,7 +232,10 @@ def test_generated_prs_dispatch_required_checks_without_an_external_token() -> N
     assert "RELEASE_PR_TOKEN" not in EMBEDDING_WORKFLOW
     assert "actions: write" in IMAGE_WORKFLOW
     assert "actions: write" in EMBEDDING_WORKFLOW
-    assert "dispatch-required-pr-checks.sh" in EMBEDDING_WORKFLOW
+    assert "dispatch-required-pr-checks.sh" in PIN_PROMOTION_SCRIPT
+    for workflow in PIN_WORKFLOWS:
+        assert "actions: write" in workflow
+        assert "propose-pin-pr.sh" in workflow
     for workflow in (
         "integration-tests.yml",
         "embedding-unit-tests.yml",
@@ -340,6 +350,51 @@ def test_embedding_pin_updater_keeps_manifest_and_dockerfile_in_sync() -> None:
         )
 
 
+def test_requirement_changes_rebuild_and_propose_embedding_toolchain_pin() -> None:
+    workflow_triggers = TOOLCHAIN_WORKFLOW.split("jobs:", maxsplit=1)[0]
+    assert "push:" in workflow_triggers
+    assert "branches: [main]" in workflow_triggers
+    assert "embedding-generation/pyproject.toml" in workflow_triggers
+    assert "embedding-generation/uv.lock" in workflow_triggers
+    assert "propose-toolchain-pin:" in TOOLCHAIN_WORKFLOW
+    assert "update-embedding-toolchain-pin.py" in TOOLCHAIN_WORKFLOW
+    assert "automation/pin-embedding-generator" in TOOLCHAIN_WORKFLOW
+    assert "cancel-in-progress: false" in TOOLCHAIN_WORKFLOW
+    assert "gh pr merge" not in TOOLCHAIN_WORKFLOW
+
+
+def test_embedding_toolchain_pin_updater_changes_only_generator_input() -> None:
+    script = REPOSITORY / ".github/scripts/update-embedding-toolchain-pin.py"
+    new_reference = "ghcr.io/arm/mcp-embedding-generator@sha256:" + "3" * 64
+
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        lock_file = Path(temporary_directory) / "pipeline-inputs.lock.json"
+        original = json.loads(
+            (
+                REPOSITORY / "embedding-generation/pipeline-inputs.lock.json"
+            ).read_text()
+        )
+        lock_file.write_text(json.dumps(original), encoding="utf-8")
+        subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--reference",
+                new_reference,
+                "--lock-file",
+                str(lock_file),
+            ],
+            check=True,
+        )
+
+        updated = json.loads(lock_file.read_text())
+        assert updated["generator_image"] == new_reference
+        assert (
+            updated["intrinsic_chunks_image"]
+            == original["intrinsic_chunks_image"]
+        )
+
+
 def test_build_input_bundle_is_immutable_and_auditable() -> None:
     build_inputs = LOCK["container_images"]["mcp_build_inputs"]
     assert build_inputs["reference"].startswith(
@@ -377,11 +432,14 @@ def test_input_artifact_has_one_platform_neutral_layout() -> None:
         assert f"!{source}" in INPUT_DOCKERIGNORE
 
 
-def test_input_publication_is_manual_private_and_multi_architecture() -> None:
+def test_input_publication_is_automatic_private_and_multi_architecture() -> None:
     assert "workflow_dispatch:" in INPUT_WORKFLOW
     workflow_triggers = INPUT_WORKFLOW.split("jobs:", maxsplit=1)[0]
     assert "permissions: read-all" in workflow_triggers
-    assert "push:" not in workflow_triggers
+    assert "push:" in workflow_triggers
+    assert "branches: [main]" in workflow_triggers
+    assert "mcp-local/pyproject.toml" in workflow_triggers
+    assert "mcp-local/uv.lock" in workflow_triggers
     assert "tags:" not in workflow_triggers
     assert "packages: write" in INPUT_WORKFLOW
     assert "verify-ghcr-package-private.sh" in INPUT_WORKFLOW
@@ -396,3 +454,114 @@ def test_input_publication_is_manual_private_and_multi_architecture() -> None:
     assert '"export",' in STAGE_INPUTS
     assert 'output / "requirements.lock"' in STAGE_INPUTS
     assert 'echo "- MCP build input: \\`${IMAGE}@${digest}\\`"' in INPUT_WORKFLOW
+    assert "propose-input-pin:" in INPUT_WORKFLOW
+    assert "update-mcp-input-pin.py" in INPUT_WORKFLOW
+    assert "automation/pin-mcp-build-inputs" in INPUT_WORKFLOW
+    assert "cancel-in-progress: false" in INPUT_WORKFLOW
+    assert "gh pr merge" not in INPUT_WORKFLOW
+
+
+def test_pin_promotions_share_review_pr_mechanics() -> None:
+    # The workflows declare what to update, while one reviewed helper owns all
+    # mutation of automation branches and pull requests.
+    assert "gh pr create" in PIN_PROMOTION_SCRIPT
+    assert "gh pr edit" in PIN_PROMOTION_SCRIPT
+    assert "dispatch-required-pr-checks.sh" in PIN_PROMOTION_SCRIPT
+    assert "gh pr merge" not in PIN_PROMOTION_SCRIPT
+    for workflow in PIN_WORKFLOWS:
+        assert "propose-pin-pr.sh" in workflow
+        assert "gh pr create" not in workflow
+        assert "gh pr edit" not in workflow
+
+
+def test_mcp_input_pin_updater_keeps_manifest_and_dockerfile_in_sync() -> None:
+    script = REPOSITORY / ".github/scripts/update-mcp-input-pin.py"
+    index_reference = "ghcr.io/arm/mcp-build-inputs@sha256:" + "4" * 64
+    amd64_reference = "ghcr.io/arm/mcp-build-inputs@sha256:" + "5" * 64
+    arm64_reference = "ghcr.io/arm/mcp-build-inputs@sha256:" + "6" * 64
+
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        temporary = Path(temporary_directory)
+        lock_file = temporary / "build-inputs.lock.json"
+        dockerfile = temporary / "Dockerfile"
+        lock_file.write_text(
+            (MCP_LOCAL / "build-inputs.lock.json").read_text(), encoding="utf-8"
+        )
+        dockerfile.write_text(
+            (MCP_LOCAL / "Dockerfile").read_text(), encoding="utf-8"
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--reference",
+                index_reference,
+                "--amd64-reference",
+                amd64_reference,
+                "--arm64-reference",
+                arm64_reference,
+                "--source-revision",
+                "7" * 40,
+                "--workflow-run",
+                "123456",
+                "--lock-file",
+                str(lock_file),
+                "--dockerfile",
+                str(dockerfile),
+            ],
+            check=True,
+        )
+
+        updated = json.loads(lock_file.read_text())["container_images"][
+            "mcp_build_inputs"
+        ]
+        assert updated["reference"] == index_reference
+        assert updated["manifests"] == {
+            "amd64": amd64_reference,
+            "arm64": arm64_reference,
+        }
+        assert updated["source_revision"] == "7" * 40
+        assert updated["workflow_run"] == "123456"
+        assert (
+            f"ARG MCP_BUILD_INPUTS_IMAGE={index_reference}"
+            in dockerfile.read_text()
+        )
+
+
+def test_mcp_input_pin_updater_preserves_provenance_for_same_bundle() -> None:
+    script = REPOSITORY / ".github/scripts/update-mcp-input-pin.py"
+    current = LOCK["container_images"]["mcp_build_inputs"]
+
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        temporary = Path(temporary_directory)
+        lock_file = temporary / "build-inputs.lock.json"
+        dockerfile = temporary / "Dockerfile"
+        original_lock = (MCP_LOCAL / "build-inputs.lock.json").read_text()
+        original_dockerfile = (MCP_LOCAL / "Dockerfile").read_text()
+        lock_file.write_text(original_lock, encoding="utf-8")
+        dockerfile.write_text(original_dockerfile, encoding="utf-8")
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--reference",
+                current["reference"],
+                "--amd64-reference",
+                current["manifests"]["amd64"],
+                "--arm64-reference",
+                current["manifests"]["arm64"],
+                "--source-revision",
+                "8" * 40,
+                "--workflow-run",
+                "654321",
+                "--lock-file",
+                str(lock_file),
+                "--dockerfile",
+                str(dockerfile),
+            ],
+            check=True,
+        )
+
+        assert lock_file.read_text() == original_lock
+        assert dockerfile.read_text() == original_dockerfile


### PR DESCRIPTION
**Summary**

- Automatically rebuilds MCP input bundles and the embedding toolchain when their source inputs change.
- Opens reviewed PRs to update the resulting immutable image pins.
- Prevents stale builds from being promoted if main advances.
- Documents automatic and manual input-refresh workflows.

Changes within `mcp-local/build-inputs.lock.json`—such as updating the Ubuntu package snapshot, Performix artifact, or migrate-ease revision—are intentionally not automatic because pin updates would cause a rebuild loop. These require a manual workflow run on main.