### PR TITLE
fix: disable Black Duck SCA policy badges creation

### DIFF
--- a/.github/workflows/black-duck-security-scan-ci.yml
+++ b/.github/workflows/black-duck-security-scan-ci.yml
@@ -76,7 +76,7 @@ jobs:
           mark_build_status: 'success'
 
           ### To enable Black Duck SCA policy badges
-          blackducksca_policy_badges_create: true
+          blackducksca_policy_badges_create: false
           blackducksca_policy_badges_maxCount: 5
 
           ### To upload Bridge diagnostic files


### PR DESCRIPTION
Disabling the policy badge creation for clean scan since its failing due to insufficient permissions for PAT token to modify repo ReadMe file to add the badge.