### PR TITLE
Add repo to GH release step

### DIFF
--- a/.github/workflows/build-mcp-image.yml
+++ b/.github/workflows/build-mcp-image.yml
@@ -607,6 +607,7 @@ jobs:
               "${ATTESTATION_URL}" "${verification_url}"
           } > "${notes_file}"
           gh release create "v${VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
             --target "${SOURCE_SHA}" \
             --title "v${VERSION}" \
             --generate-notes \

--- a/mcp-local/tests/test_build_inputs.py
+++ b/mcp-local/tests/test_build_inputs.py
@@ -312,6 +312,7 @@ def test_release_attests_and_verifies_the_final_production_digest() -> None:
     assert '${IMAGE}:latest' not in publish_image_job
     assert "Promote verified image to latest" in publish_release_job
     assert '"${IMAGE_FQDN}@${DIGEST}"' in publish_release_job
+    assert '--repo "${GITHUB_REPOSITORY}"' in publish_release_job
     assert "Immutable digest:" in IMAGE_WORKFLOW
     assert "verification instructions" in IMAGE_WORKFLOW
     assert "blob/main/docs/provenance-verification.md" not in IMAGE_WORKFLOW


### PR DESCRIPTION
Will fix the error encountered in https://github.com/arm/mcp/actions/runs/32878277502/job/97903043093 
All previous steps before Github release, including upload to Docker Hub, worked fine.
I was able to manually release 2.12.1 on Github, so no further action is needed once this is merged.