### PR TITLE
Move to reusable workflow, add/update documentation

### DIFF
--- a/.github/workflows/build-mcp-image.yml
+++ b/.github/workflows/build-mcp-image.yml
@@ -24,13 +24,8 @@ on:
 permissions:
   contents: read
 
-env:
-  IMAGE: armlimited/arm-mcp
-  IMAGE_FQDN: docker.io/armlimited/arm-mcp
-  STRACE_VERSION: 6.8-0ubuntu2
-
-# Version PRs serialize naturally at merge time, but publication remains
-# serialized so two closely spaced releases cannot race when updating latest.
+# Version PRs serialize naturally at merge time. The production reusable call
+# remains serialized so closely spaced releases cannot race when updating latest.
 concurrency:
   group: ${{ github.event_name == 'push' && 'build-mcp-image-publish' || format('build-mcp-image-{0}', github.run_id) }}
   cancel-in-progress: false
@@ -98,31 +93,20 @@ jobs:
             echo "- Pull request: ${pr_url}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-  validate-release:
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.release_action == 'dry-run' }}
+  validate-version-pr:
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    outputs:
-      version: ${{ steps.release.outputs.version }}
-      source_sha: ${{ steps.release.outputs.source_sha }}
-      publish: ${{ steps.release.outputs.publish }}
-      build: ${{ steps.release.outputs.build }}
     steps:
-      - name: Checkout reviewed release commit
+      - name: Checkout proposed release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Validate reviewed release version
-        id: release
+      - name: Validate proposed release version
         shell: bash
-        env:
-          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          CHECK_TAG: ${{ github.event_name != 'workflow_dispatch' }}
-          BUILD: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
-          PUBLISH: ${{ github.event_name == 'push' }}
         run: |
           set -euo pipefail
           server_file="mcp-local/server.json"
@@ -132,7 +116,7 @@ jobs:
             exit 1
           fi
 
-          expected_image="docker.io/${IMAGE}:${version}"
+          expected_image="docker.io/armlimited/arm-mcp:${version}"
           if ! jq -e --arg image "${expected_image}" '
             [.packages[]? | select(.registryType == "oci") | .identifier] | index($image) != null
           ' "${server_file}" > /dev/null; then
@@ -140,475 +124,46 @@ jobs:
             exit 1
           fi
 
-          if [ "${CHECK_TAG}" = "true" ] && git rev-parse -q --verify "refs/tags/v${version}" > /dev/null; then
+          if git rev-parse -q --verify "refs/tags/v${version}" > /dev/null; then
             echo "::error::Release tag v${version} already exists. Submit a new reviewed version PR."
             exit 1
           fi
 
-          {
-            echo "version=${version}"
-            echo "source_sha=${SOURCE_SHA}"
-            echo "publish=${PUBLISH}"
-            echo "build=${BUILD}"
-          } >> "${GITHUB_OUTPUT}"
-
-          if [ "${BUILD}" = "true" ] && [ "${PUBLISH}" != "true" ]; then
-            echo "Manual runs validate and build the selected commit but never publish." >> "${GITHUB_STEP_SUMMARY}"
-          fi
-
-  build-arch-images:
-    needs: validate-release
-    if: ${{ needs.validate-release.outputs.build == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-24.04
-            platform: linux/amd64
-            tag: amd64
-          - runner: ubuntu-24.04-arm
-            platform: linux/arm64
-            tag: arm64
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-      packages: read
-    steps:
-      - name: Checkout reviewed release commit
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ needs.validate-release.outputs.source_sha }}
-
-      - name: Load locked image references
-        id: locked_images
-        shell: bash
-        run: |
-          set -euo pipefail
-          lock_file="mcp-local/build-inputs.lock.json"
-          dockerfile="mcp-local/Dockerfile"
-
-          load_image() {
-            local key="$1"
-            local docker_arg="$2"
-            local output_name="$3"
-            local reference
-            reference="$(jq -er --arg key "${key}" '.container_images[$key].reference | select(type == "string")' "${lock_file}")"
-
-            if [[ ! "${reference}" =~ ^[^@[:space:]]+@sha256:[0-9a-f]{64}$ ]]; then
-              echo "::error::${key} is not pinned to an immutable image digest: ${reference}"
-              exit 1
-            fi
-            if ! grep -Fqx "ARG ${docker_arg}=${reference}" "${dockerfile}"; then
-              echo "::error::${docker_arg} default does not match ${key} in ${lock_file}."
-              exit 1
-            fi
-            echo "${output_name}=${reference}" >> "${GITHUB_OUTPUT}"
-          }
-
-          load_image ubuntu UBUNTU_IMAGE ubuntu_image
-          load_image embeddings EMBEDDINGS_IMAGE embeddings_image
-          load_image mcp_build_inputs MCP_BUILD_INPUTS_IMAGE mcp_build_inputs_image
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-
-      - name: Log in to GHCR for locked build inputs
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Log in to Docker Hub
-        if: ${{ needs.validate-release.outputs.publish == 'true' }}
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build ${{ matrix.platform }} image
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          file: mcp-local/Dockerfile
-          platforms: ${{ matrix.platform }}
-          network: none
-          build-args: |
-            UBUNTU_IMAGE=${{ steps.locked_images.outputs.ubuntu_image }}
-            EMBEDDINGS_IMAGE=${{ steps.locked_images.outputs.embeddings_image }}
-            MCP_BUILD_INPUTS_IMAGE=${{ steps.locked_images.outputs.mcp_build_inputs_image }}
-          push: ${{ needs.validate-release.outputs.publish == 'true' }}
-          load: ${{ needs.validate-release.outputs.publish != 'true' }}
-          tags: ${{ env.IMAGE }}:${{ needs.validate-release.outputs.version }}-${{ matrix.tag }}
-
-      - name: Install runtime egress tracer
-        id: install_strace
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends "strace=${STRACE_VERSION}"
-          installed_version="$(dpkg-query --show --showformat='${Version}' strace)"
-          if [ "${installed_version}" != "${STRACE_VERSION}" ]; then
-            echo "::error::Installed strace ${installed_version}; expected ${STRACE_VERSION}."
-            exit 1
-          fi
-          echo "version=${installed_version}" >> "${GITHUB_OUTPUT}"
-
-      - name: Select exact image produced by the build
-        id: runtime_image
-        shell: bash
-        env:
-          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
-          PUBLISH: ${{ needs.validate-release.outputs.publish }}
-          VERSION: ${{ needs.validate-release.outputs.version }}
-          ARCH_TAG: ${{ matrix.tag }}
-        run: |
-          set -euo pipefail
-          if [[ ! "${BUILD_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::Build did not produce an immutable image digest: ${BUILD_DIGEST}"
-            exit 1
-          fi
-
-          if [ "${PUBLISH}" = "true" ]; then
-            image="${IMAGE}@${BUILD_DIGEST}"
-            docker pull --platform "${{ matrix.platform }}" "${image}"
-          else
-            image="${IMAGE}:${VERSION}-${ARCH_TAG}"
-          fi
-          echo "image=${image}" >> "${GITHUB_OUTPUT}"
-
-      - name: Validate runtime has no unapproved egress
-        env:
-          IMAGE_REFERENCE: ${{ steps.runtime_image.outputs.image }}
-          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
-          PLATFORM: ${{ matrix.platform }}
-          EVIDENCE_DIR: ${{ runner.temp }}/runtime-egress-${{ matrix.tag }}
-          STRACE_PACKAGE_VERSION: ${{ steps.install_strace.outputs.version }}
-        run: |
-          python3 mcp-local/scripts/validate-runtime-egress.py \
-            --image "${IMAGE_REFERENCE}" \
-            --digest "${BUILD_DIGEST}" \
-            --platform "${PLATFORM}" \
-            --workspace mcp-local \
-            --strace-package-version "${STRACE_PACKAGE_VERSION}" \
-            --evidence-dir "${EVIDENCE_DIR}"
-
-      - name: Record validated image digest
-        env:
-          ARCH_TAG: ${{ matrix.tag }}
-          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          set -euo pipefail
-          if [[ ! "${BUILD_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::Cannot record invalid image digest: ${BUILD_DIGEST}"
-            exit 1
-          fi
-          printf '%s\n' "${BUILD_DIGEST}" > "${RUNNER_TEMP}/validated-image-digest-${ARCH_TAG}.txt"
-
-      - name: Retain validated image digest
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: validated-image-digest-${{ matrix.tag }}-${{ github.run_id }}
-          path: ${{ runner.temp }}/validated-image-digest-${{ matrix.tag }}.txt
-          if-no-files-found: error
-          retention-days: 90
-
-      - name: Add runtime validation summary
-        if: ${{ always() }}
-        env:
-          EVIDENCE_DIR: ${{ runner.temp }}/runtime-egress-${{ matrix.tag }}
-        run: |
-          if [ -f "${EVIDENCE_DIR}/summary.md" ]; then
-            cat "${EVIDENCE_DIR}/summary.md" >> "${GITHUB_STEP_SUMMARY}"
-          else
-            echo "::error::Runtime egress validation produced no summary."
-            exit 1
-          fi
-
-      - name: Retain runtime validation evidence
-        if: ${{ always() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: runtime-egress-${{ matrix.tag }}-${{ github.run_id }}
-          path: ${{ runner.temp }}/runtime-egress-${{ matrix.tag }}/
-          if-no-files-found: error
-          retention-days: 90
-
-  record-dry-run:
-    needs:
-      - validate-release
-      - build-arch-images
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
+  dry-run:
     if: >-
       ${{
-        needs.build-arch-images.result == 'success'
-        && needs.validate-release.outputs.publish != 'true'
+        github.repository == 'arm/mcp'
+        && github.event_name == 'workflow_dispatch'
+        && inputs.release_action == 'dry-run'
       }}
-    steps:
-      - name: Record successful manual build
-        env:
-          VERSION: ${{ needs.validate-release.outputs.version }}
-          SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
-        run: |
-          {
-            echo "### MCP release dry run"
-            echo ""
-            echo "- Version: \`${VERSION}\`"
-            echo "- Source commit: \`${SOURCE_SHA}\`"
-            echo "- AMD64 and Arm64 builds and runtime egress validations succeeded without publication."
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-  publish-image:
-    needs:
-      - validate-release
-      - build-arch-images
-    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
+      packages: read
+    uses: ./.github/workflows/trusted-mcp-release.yml
+    with:
+      release_mode: dry-run
+
+  production:
     if: >-
       ${{
-        needs.build-arch-images.result == 'success'
-        && needs.validate-release.outputs.publish == 'true'
+        github.repository == 'arm/mcp'
+        && github.event_name == 'push'
+        && github.ref == 'refs/heads/main'
+        && github.ref_type == 'branch'
+        && github.ref_protected == true
+        && github.sha == github.event.after
       }}
-    outputs:
-      digest: ${{ steps.final_image_digest.outputs.digest }}
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Download validated image digests
-        if: ${{ needs.validate-release.outputs.publish == 'true' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: validated-image-digest-*-${{ github.run_id }}
-          path: ${{ runner.temp }}/validated-image-digests
-          merge-multiple: true
-
-      - name: Publish multi-architecture release
-        env:
-          DIGEST_DIR: ${{ runner.temp }}/validated-image-digests
-          VERSION: ${{ needs.validate-release.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          read_digest() {
-            local architecture="$1"
-            local digest_file="${DIGEST_DIR}/validated-image-digest-${architecture}.txt"
-            local digest
-            if [ ! -f "${digest_file}" ]; then
-              echo "::error::Missing validated ${architecture} image digest artifact." >&2
-              return 1
-            fi
-            digest="$(tr -d '\r\n' < "${digest_file}")"
-            if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-              echo "::error::Invalid validated ${architecture} image digest: ${digest}" >&2
-              return 1
-            fi
-            printf '%s\n' "${digest}"
-          }
-
-          amd64_digest="$(read_digest amd64)"
-          arm64_digest="$(read_digest arm64)"
-          docker buildx imagetools create \
-            --metadata-file "${RUNNER_TEMP}/manifest-metadata.json" \
-            -t "${IMAGE}:${VERSION}" \
-            "${IMAGE}@${amd64_digest}" \
-            "${IMAGE}@${arm64_digest}"
-
-      - name: Resolve and validate final image digest
-        id: final_image_digest
-        env:
-          VERSION: ${{ needs.validate-release.outputs.version }}
-        run: |
-          set -euo pipefail
-          created_digest="$(
-            jq -r \
-              '."containerimage.descriptor".digest // empty' \
-              "${RUNNER_TEMP}/manifest-metadata.json"
-          )"
-          inspected_digest="$(
-            docker buildx imagetools inspect \
-              "${IMAGE}:${VERSION}" \
-              --format '{{json .Manifest}}' |
-              jq -r '.digest // empty'
-          )"
-
-          if [[ ! "${created_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::Published image digest is missing or invalid."
-            exit 1
-          fi
-          if [ "${created_digest}" != "${inspected_digest}" ]; then
-            echo "::error::Published and registry-resolved image digests differ."
-            echo "Published: ${created_digest}"
-            echo "Registry: ${inspected_digest}"
-            exit 1
-          fi
-
-          echo "digest=${created_digest}" >> "${GITHUB_OUTPUT}"
-          echo "Resolved ${IMAGE_FQDN}@${created_digest}"
-
-  attest-image:
-    name: Attest production image provenance
-    needs:
-      - publish-image
-    runs-on: ubuntu-24.04
-    if: ${{ needs.publish-image.result == 'success' }}
     permissions:
-      contents: read
+      actions: read
+      contents: write
+      packages: read
       id-token: write
       attestations: write
       artifact-metadata: write
-    outputs:
-      attestation-url: ${{ steps.attest.outputs.attestation-url }}
-    steps:
-      - name: Validate final image digest
-        env:
-          DIGEST: ${{ needs.publish-image.outputs.digest }}
-        run: |
-          set -euo pipefail
-          if [[ ! "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::Attestation subject digest is missing or invalid."
-            exit 1
-          fi
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Generate and publish provenance
-        id: attest
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-name: ${{ env.IMAGE_FQDN }}
-          subject-digest: ${{ needs.publish-image.outputs.digest }}
-          push-to-registry: true
-
-      - name: Validate attestation output
-        env:
-          ATTESTATION_URL: ${{ steps.attest.outputs.attestation-url }}
-        run: |
-          set -euo pipefail
-          if [ -z "${ATTESTATION_URL}" ]; then
-            echo "::error::Attestation action did not return an attestation URL."
-            exit 1
-          fi
-          echo "Attestation: ${ATTESTATION_URL}" >> "${GITHUB_STEP_SUMMARY}"
-
-  verify-provenance:
-    needs:
-      - validate-release
-      - publish-image
-      - attest-image
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      attestations: read
-    if: ${{ needs.attest-image.result == 'success' }}
-    steps:
-      - name: Log in to Docker Hub
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Verify provenance through GitHub
-        env:
-          GH_TOKEN: ${{ github.token }}
-          DIGEST: ${{ needs.publish-image.outputs.digest }}
-          SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
-        run: |
-          set -euo pipefail
-          gh attestation verify \
-            "oci://${IMAGE_FQDN}@${DIGEST}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/build-mcp-image.yml" \
-            --source-ref refs/heads/main \
-            --source-digest "${SOURCE_SHA}"
-
-      - name: Verify registry-attached provenance
-        env:
-          GH_TOKEN: ${{ github.token }}
-          DIGEST: ${{ needs.publish-image.outputs.digest }}
-          SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
-        run: |
-          set -euo pipefail
-          gh attestation verify \
-            "oci://${IMAGE_FQDN}@${DIGEST}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/build-mcp-image.yml" \
-            --source-ref refs/heads/main \
-            --source-digest "${SOURCE_SHA}" \
-            --bundle-from-oci
-
-  publish-release:
-    needs:
-      - validate-release
-      - publish-image
-      - attest-image
-      - verify-provenance
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    if: >-
-      ${{
-        always()
-        && needs.publish-image.result == 'success'
-        && needs.verify-provenance.result == 'success'
-      }}
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Promote verified image to latest
-        env:
-          DIGEST: ${{ needs.publish-image.outputs.digest }}
-        run: |
-          set -euo pipefail
-          docker buildx imagetools create \
-            -t "${IMAGE}:latest" \
-            "${IMAGE_FQDN}@${DIGEST}"
-
-      - name: Create tag and GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.validate-release.outputs.version }}
-          SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
-          DIGEST: ${{ needs.publish-image.outputs.digest }}
-          ATTESTATION_URL: ${{ needs.attest-image.outputs.attestation-url }}
-        run: |
-          set -euo pipefail
-          notes_file="${RUNNER_TEMP}/release-notes.md"
-          verification_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/${SOURCE_SHA}/docs/provenance-verification.md"
-          {
-            printf "Docker image: \`%s:%s\`\n" "${IMAGE_FQDN}" "${VERSION}"
-            printf "Immutable digest: \`%s\`\n" "${DIGEST}"
-            printf "Source commit: [\`%s\`](%s/%s/commit/%s)\n" \
-              "${SOURCE_SHA}" "${GITHUB_SERVER_URL}" \
-              "${GITHUB_REPOSITORY}" "${SOURCE_SHA}"
-            printf "Provenance: [attestation](%s) · [verification instructions](%s)\n" \
-              "${ATTESTATION_URL}" "${verification_url}"
-          } > "${notes_file}"
-          gh release create "v${VERSION}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --target "${SOURCE_SHA}" \
-            --title "v${VERSION}" \
-            --generate-notes \
-            --notes-file "${notes_file}"
+    uses: ./.github/workflows/trusted-mcp-release.yml
+    with:
+      release_mode: production
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-mcp-image.yml
+++ b/.github/workflows/build-mcp-image.yml
@@ -24,6 +24,9 @@ on:
 permissions:
   contents: read
 
+env:
+  IMAGE_FQDN: docker.io/armlimited/arm-mcp
+
 # Version PRs serialize naturally at merge time. The production reusable call
 # remains serialized so closely spaced releases cannot race when updating latest.
 concurrency:
@@ -116,7 +119,7 @@ jobs:
             exit 1
           fi
 
-          expected_image="docker.io/armlimited/arm-mcp:${version}"
+          expected_image="${IMAGE_FQDN}:${version}"
           if ! jq -e --arg image "${expected_image}" '
             [.packages[]? | select(.registryType == "oci") | .identifier] | index($image) != null
           ' "${server_file}" > /dev/null; then
@@ -137,9 +140,16 @@ jobs:
         && inputs.release_action == 'dry-run'
       }}
     permissions:
+      # GitHub validates every nested job's maximum permissions before it
+      # evaluates mode-specific conditions. Jobs that execute in dry-run mode
+      # explicitly downgrade these permissions, and this call receives no
+      # production secrets.
       actions: read
-      contents: read
+      contents: write
       packages: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     uses: ./.github/workflows/trusted-mcp-release.yml
     with:
       release_mode: dry-run

--- a/.github/workflows/trusted-mcp-release.yml
+++ b/.github/workflows/trusted-mcp-release.yml
@@ -1,0 +1,611 @@
+name: Trusted MCP Release
+
+on:
+  workflow_call:
+    inputs:
+      release_mode:
+        description: Requested operation; authorization is derived from the caller context
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+env:
+  IMAGE: armlimited/arm-mcp
+  IMAGE_FQDN: docker.io/armlimited/arm-mcp
+  STRACE_VERSION: 6.8-0ubuntu2
+
+jobs:
+  authorize:
+    name: Authorize original caller context
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      mode: ${{ steps.authorization.outputs.mode }}
+      source_sha: ${{ steps.authorization.outputs.source_sha }}
+    steps:
+      - name: Fail closed unless invocation is authorized
+        id: authorization
+        shell: bash
+        env:
+          REQUESTED_MODE: ${{ inputs.release_mode }}
+          CALLER_REPOSITORY: ${{ github.repository }}
+          CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
+          CALLER_EVENT: ${{ github.event_name }}
+          CALLER_REF: ${{ github.ref }}
+          CALLER_REF_TYPE: ${{ github.ref_type }}
+          CALLER_REF_PROTECTED: ${{ github.ref_protected }}
+          CALLER_SHA: ${{ github.sha }}
+          PUSH_AFTER: ${{ github.event.after }}
+          DISPATCH_ACTION: ${{ github.event.inputs.release_action }}
+        run: |
+          set -euo pipefail
+
+          production_authorized=false
+          if [ "${REQUESTED_MODE}" = "production" ] \
+            && [ "${CALLER_REPOSITORY}" = "arm/mcp" ] \
+            && [ "${CALLER_WORKFLOW_REF}" = "arm/mcp/.github/workflows/build-mcp-image.yml@refs/heads/main" ] \
+            && [ "${CALLER_EVENT}" = "push" ] \
+            && [ "${CALLER_REF}" = "refs/heads/main" ] \
+            && [ "${CALLER_REF_TYPE}" = "branch" ] \
+            && [ "${CALLER_REF_PROTECTED}" = "true" ] \
+            && [ "${CALLER_SHA}" = "${PUSH_AFTER}" ]; then
+            production_authorized=true
+          fi
+
+          dry_run_authorized=false
+          if [ "${REQUESTED_MODE}" = "dry-run" ] \
+            && [ "${CALLER_REPOSITORY}" = "arm/mcp" ] \
+            && [ "${CALLER_EVENT}" = "workflow_dispatch" ] \
+            && [ "${DISPATCH_ACTION}" = "dry-run" ]; then
+            dry_run_authorized=true
+          fi
+
+          if [ "${production_authorized}" = "true" ]; then
+            authorized_mode=production
+          elif [ "${dry_run_authorized}" = "true" ]; then
+            authorized_mode=dry-run
+          else
+            echo "::error::Unauthorized trusted release invocation."
+            echo "Production requires the exact protected-main push context; dry-run requires a manual dry-run dispatch from arm/mcp."
+            exit 1
+          fi
+
+          if [[ ! "${CALLER_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Authorized source commit is not a complete Git SHA: ${CALLER_SHA}"
+            exit 1
+          fi
+
+          {
+            echo "mode=${authorized_mode}"
+            echo "source_sha=${CALLER_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "Authorized ${authorized_mode} for ${CALLER_REPOSITORY}@${CALLER_SHA}." >> "${GITHUB_STEP_SUMMARY}"
+
+  validate-release:
+    needs: authorize
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      source_sha: ${{ needs.authorize.outputs.source_sha }}
+      mode: ${{ needs.authorize.outputs.mode }}
+    steps:
+      - name: Checkout exact authorized source commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.authorize.outputs.source_sha }}
+          fetch-depth: 0
+
+      - name: Validate authorized release version and source
+        id: release
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ needs.authorize.outputs.source_sha }}
+          RELEASE_MODE: ${{ needs.authorize.outputs.mode }}
+        run: |
+          set -euo pipefail
+          if [ "$(git rev-parse HEAD)" != "${SOURCE_SHA}" ]; then
+            echo "::error::Checkout does not match the authorized source commit."
+            exit 1
+          fi
+
+          server_file="mcp-local/server.json"
+          version="$(jq -er '.version | select(type == "string")' "${server_file}")"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::server.json version must use X.Y.Z semantic versioning: ${version}"
+            exit 1
+          fi
+
+          expected_image="docker.io/${IMAGE}:${version}"
+          if ! jq -e --arg image "${expected_image}" '
+            [.packages[]? | select(.registryType == "oci") | .identifier] | index($image) != null
+          ' "${server_file}" > /dev/null; then
+            echo "::error::server.json must identify the release image as ${expected_image}."
+            exit 1
+          fi
+
+          if [ "${RELEASE_MODE}" = "production" ] \
+            && git rev-parse -q --verify "refs/tags/v${version}" > /dev/null; then
+            echo "::error::Release tag v${version} already exists. Submit a new reviewed version PR."
+            exit 1
+          fi
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          if [ "${RELEASE_MODE}" = "dry-run" ]; then
+            echo "Manual dry runs build and validate the selected commit but never publish." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+  build-arch-images:
+    needs: validate-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+            tag: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            tag: arm64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout exact authorized source commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.validate-release.outputs.source_sha }}
+
+      - name: Load locked image references
+        id: locked_images
+        shell: bash
+        run: |
+          set -euo pipefail
+          lock_file="mcp-local/build-inputs.lock.json"
+          dockerfile="mcp-local/Dockerfile"
+
+          load_image() {
+            local key="$1"
+            local docker_arg="$2"
+            local output_name="$3"
+            local reference
+            reference="$(
+              jq -er \
+                --arg key "${key}" \
+                '.container_images[$key].reference | select(type == "string")' \
+                "${lock_file}"
+            )"
+
+            if [[ ! "${reference}" =~ ^[^@[:space:]]+@sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::${key} is not pinned to an immutable image digest: ${reference}"
+              exit 1
+            fi
+            if ! grep -Fqx "ARG ${docker_arg}=${reference}" "${dockerfile}"; then
+              echo "::error::${docker_arg} default does not match ${key} in ${lock_file}."
+              exit 1
+            fi
+            echo "${output_name}=${reference}" >> "${GITHUB_OUTPUT}"
+          }
+
+          load_image ubuntu UBUNTU_IMAGE ubuntu_image
+          load_image embeddings EMBEDDINGS_IMAGE embeddings_image
+          load_image mcp_build_inputs MCP_BUILD_INPUTS_IMAGE mcp_build_inputs_image
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      - name: Log in to GHCR for locked build inputs
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Log in to Docker Hub
+        if: ${{ needs.validate-release.outputs.mode == 'production' }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build ${{ matrix.platform }} image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: mcp-local/Dockerfile
+          platforms: ${{ matrix.platform }}
+          network: none
+          build-args: |
+            UBUNTU_IMAGE=${{ steps.locked_images.outputs.ubuntu_image }}
+            EMBEDDINGS_IMAGE=${{ steps.locked_images.outputs.embeddings_image }}
+            MCP_BUILD_INPUTS_IMAGE=${{ steps.locked_images.outputs.mcp_build_inputs_image }}
+          push: ${{ needs.validate-release.outputs.mode == 'production' }}
+          load: ${{ needs.validate-release.outputs.mode == 'dry-run' }}
+          tags: ${{ env.IMAGE }}:${{ needs.validate-release.outputs.version }}-${{ matrix.tag }}
+
+      - name: Install runtime egress tracer
+        id: install_strace
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends "strace=${STRACE_VERSION}"
+          installed_version="$(dpkg-query --show --showformat='${Version}' strace)"
+          if [ "${installed_version}" != "${STRACE_VERSION}" ]; then
+            echo "::error::Installed strace ${installed_version}; expected ${STRACE_VERSION}."
+            exit 1
+          fi
+          echo "version=${installed_version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Select exact image produced by the build
+        id: runtime_image
+        shell: bash
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          RELEASE_MODE: ${{ needs.validate-release.outputs.mode }}
+          VERSION: ${{ needs.validate-release.outputs.version }}
+          ARCH_TAG: ${{ matrix.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${BUILD_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Build did not produce an immutable image digest: ${BUILD_DIGEST}"
+            exit 1
+          fi
+
+          if [ "${RELEASE_MODE}" = "production" ]; then
+            image="${IMAGE}@${BUILD_DIGEST}"
+            docker pull --platform "${{ matrix.platform }}" "${image}"
+          else
+            image="${IMAGE}:${VERSION}-${ARCH_TAG}"
+          fi
+          echo "image=${image}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate runtime has no unapproved egress
+        env:
+          IMAGE_REFERENCE: ${{ steps.runtime_image.outputs.image }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          PLATFORM: ${{ matrix.platform }}
+          EVIDENCE_DIR: ${{ runner.temp }}/runtime-egress-${{ matrix.tag }}
+          STRACE_PACKAGE_VERSION: ${{ steps.install_strace.outputs.version }}
+        run: |
+          python3 mcp-local/scripts/validate-runtime-egress.py \
+            --image "${IMAGE_REFERENCE}" \
+            --digest "${BUILD_DIGEST}" \
+            --platform "${PLATFORM}" \
+            --workspace mcp-local \
+            --strace-package-version "${STRACE_PACKAGE_VERSION}" \
+            --evidence-dir "${EVIDENCE_DIR}"
+
+      - name: Record validated image digest
+        env:
+          ARCH_TAG: ${{ matrix.tag }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${BUILD_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Cannot record invalid image digest: ${BUILD_DIGEST}"
+            exit 1
+          fi
+          printf '%s\n' "${BUILD_DIGEST}" > "${RUNNER_TEMP}/validated-image-digest-${ARCH_TAG}.txt"
+
+      - name: Retain validated image digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: validated-image-digest-${{ matrix.tag }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/validated-image-digest-${{ matrix.tag }}.txt
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Add runtime validation summary
+        if: ${{ always() }}
+        env:
+          EVIDENCE_DIR: ${{ runner.temp }}/runtime-egress-${{ matrix.tag }}
+        run: |
+          if [ -f "${EVIDENCE_DIR}/summary.md" ]; then
+            cat "${EVIDENCE_DIR}/summary.md" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "::error::Runtime egress validation produced no summary."
+            exit 1
+          fi
+
+      - name: Retain runtime validation evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: runtime-egress-${{ matrix.tag }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/runtime-egress-${{ matrix.tag }}/
+          if-no-files-found: error
+          retention-days: 90
+
+  record-dry-run:
+    needs:
+      - validate-release
+      - build-arch-images
+    if: >-
+      ${{
+        needs.build-arch-images.result == 'success'
+        && needs.validate-release.outputs.mode == 'dry-run'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Record successful manual build
+        env:
+          VERSION: ${{ needs.validate-release.outputs.version }}
+          SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
+        run: |
+          {
+            echo "### MCP release dry run"
+            echo ""
+            echo "- Version: \`${VERSION}\`"
+            echo "- Source commit: \`${SOURCE_SHA}\`"
+            echo "- AMD64 and Arm64 builds and runtime egress validations succeeded."
+            echo "- No image, manifest, attestation, tag, or release was published."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  publish-image:
+    needs:
+      - validate-release
+      - build-arch-images
+    if: >-
+      ${{
+        needs.build-arch-images.result == 'success'
+        && needs.validate-release.outputs.mode == 'production'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      digest: ${{ steps.final_image_digest.outputs.digest }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download validated image digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: validated-image-digest-*-${{ github.run_id }}
+          path: ${{ runner.temp }}/validated-image-digests
+          merge-multiple: true
+
+      - name: Publish multi-architecture release from validated digests
+        env:
+          DIGEST_DIR: ${{ runner.temp }}/validated-image-digests
+          VERSION: ${{ needs.validate-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          read_digest() {
+            local architecture="$1"
+            local digest_file="${DIGEST_DIR}/validated-image-digest-${architecture}.txt"
+            local digest
+            if [ ! -f "${digest_file}" ]; then
+              echo "::error::Missing validated ${architecture} image digest artifact." >&2
+              return 1
+            fi
+            digest="$(tr -d '\r\n' < "${digest_file}")"
+            if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::Invalid validated ${architecture} image digest: ${digest}" >&2
+              return 1
+            fi
+            printf '%s\n' "${digest}"
+          }
+
+          amd64_digest="$(read_digest amd64)"
+          arm64_digest="$(read_digest arm64)"
+          docker buildx imagetools create \
+            --metadata-file "${RUNNER_TEMP}/manifest-metadata.json" \
+            -t "${IMAGE}:${VERSION}" \
+            "${IMAGE}@${amd64_digest}" \
+            "${IMAGE}@${arm64_digest}"
+
+      - name: Resolve and validate final image digest
+        id: final_image_digest
+        env:
+          VERSION: ${{ needs.validate-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          created_digest="$(
+            jq -r \
+              '."containerimage.descriptor".digest // empty' \
+              "${RUNNER_TEMP}/manifest-metadata.json"
+          )"
+          inspected_digest="$(
+            docker buildx imagetools inspect \
+              "${IMAGE}:${VERSION}" \
+              --format '{{json .Manifest}}' |
+              jq -r '.digest // empty'
+          )"
+
+          if [[ ! "${created_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Published image digest is missing or invalid."
+            exit 1
+          fi
+          if [ "${created_digest}" != "${inspected_digest}" ]; then
+            echo "::error::Published and registry-resolved image digests differ."
+            echo "Published: ${created_digest}"
+            echo "Registry: ${inspected_digest}"
+            exit 1
+          fi
+
+          echo "digest=${created_digest}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved ${IMAGE_FQDN}@${created_digest}"
+
+  attest-image:
+    name: Attest production image provenance
+    needs: publish-image
+    if: ${{ needs.publish-image.result == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    outputs:
+      attestation-url: ${{ steps.attest.outputs.attestation-url }}
+    steps:
+      - name: Validate final image digest
+        env:
+          DIGEST: ${{ needs.publish-image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Attestation subject digest is missing or invalid."
+            exit 1
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Generate and publish provenance
+        id: attest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE_FQDN }}
+          subject-digest: ${{ needs.publish-image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Validate attestation output
+        env:
+          ATTESTATION_URL: ${{ steps.attest.outputs.attestation-url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ATTESTATION_URL}" ]; then
+            echo "::error::Attestation action did not return an attestation URL."
+            exit 1
+          fi
+          echo "Attestation: ${ATTESTATION_URL}" >> "${GITHUB_STEP_SUMMARY}"
+
+  verify-provenance:
+    needs:
+      - validate-release
+      - publish-image
+      - attest-image
+    if: ${{ needs.attest-image.result == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      attestations: read
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Verify provenance through GitHub
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIGEST: ${{ needs.publish-image.outputs.digest }}
+          SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          gh attestation verify \
+            "oci://${IMAGE_FQDN}@${DIGEST}" \
+            --repo arm/mcp \
+            --signer-workflow arm/mcp/.github/workflows/trusted-mcp-release.yml \
+            --source-ref refs/heads/main \
+            --source-digest "${SOURCE_SHA}"
+
+      - name: Verify registry-attached provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIGEST: ${{ needs.publish-image.outputs.digest }}
+          SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          gh attestation verify \
+            "oci://${IMAGE_FQDN}@${DIGEST}" \
+            --repo arm/mcp \
+            --signer-workflow arm/mcp/.github/workflows/trusted-mcp-release.yml \
+            --source-ref refs/heads/main \
+            --source-digest "${SOURCE_SHA}" \
+            --bundle-from-oci
+
+  publish-release:
+    needs:
+      - validate-release
+      - publish-image
+      - attest-image
+      - verify-provenance
+    if: >-
+      ${{
+        always()
+        && needs.publish-image.result == 'success'
+        && needs.attest-image.result == 'success'
+        && needs.verify-provenance.result == 'success'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Promote verified image to latest
+        env:
+          DIGEST: ${{ needs.publish-image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t "${IMAGE}:latest" \
+            "${IMAGE_FQDN}@${DIGEST}"
+
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate-release.outputs.version }}
+          SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
+          DIGEST: ${{ needs.publish-image.outputs.digest }}
+          ATTESTATION_URL: ${{ needs.attest-image.outputs.attestation-url }}
+        run: |
+          set -euo pipefail
+          notes_file="${RUNNER_TEMP}/release-notes.md"
+          docs_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/${SOURCE_SHA}/docs"
+          verification_url="${docs_url}/provenance-verification.md"
+          assurance_url="${docs_url}/slsa-build-level-3.md"
+          {
+            printf "Docker image: \`%s:%s\`\n" "${IMAGE_FQDN}" "${VERSION}"
+            printf "Immutable digest: \`%s\`\n" "${DIGEST}"
+            printf "Source commit: [\`%s\`](%s/%s/commit/%s)\n" \
+              "${SOURCE_SHA}" "${GITHUB_SERVER_URL}" \
+              "${GITHUB_REPOSITORY}" "${SOURCE_SHA}"
+            printf "Provenance: [attestation](%s) · [source-pinned verification instructions](%s)\n" \
+              "${ATTESTATION_URL}" "${verification_url}"
+            printf "SLSA Build Level 3: [how the trusted build meets the requirements](%s)\n" \
+              "${assurance_url}"
+          } > "${notes_file}"
+          gh release create "v${VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${SOURCE_SHA}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            --notes-file "${notes_file}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,7 +307,7 @@ from unsuccessful or unwanted embedding candidates.
 Production releases are initiated only by a reviewed PR that updates
 `mcp-local/server.json` on `main`. Embedding promotion PRs make this update
 automatically as a minor release. For a release that does not promote a new
-embedding, ask the workflow to create a reviewed version PR:
+embedding, use the normal release procedure:
 
 1. Start **Build MCP Image** manually and select `hotfix`, `minor`, or `major`.
    From the CLI, for example:
@@ -319,12 +319,19 @@ embedding, ask the workflow to create a reviewed version PR:
 2. The workflow opens or updates a version PR with the matching semantic
    version change in `mcp-local/server.json`.
 3. Allow the required status checks and security-team review to complete.
-4. Merge the approved PR. **Build MCP Image** validates the version, builds the
-   exact merge commit for AMD64 and Arm64, publishes the version and `latest`
-   tags, and creates the matching `vX.Y.Z` Git tag and GitHub Release.
+4. Merge the approved PR. The trusted workflow builds AMD64 and Arm64 images,
+   verifies their provenance, and publishes the image tags and GitHub Release.
+5. Verify the release using the digest and commit recorded in the GitHub Release
+   and the [provenance verification guide](docs/provenance-verification.md).
 
-Manual workflow runs are dry runs: they build both architectures but cannot
-publish images, tags, or releases when `dry-run` is selected.
+For a dry run, start **Build MCP Image** with `release_action=dry-run`. Confirm
+that both architectures and both runtime-egress checks pass, and that the
+summary says no image, manifest, attestation, tag, or release was published.
+
+To roll back a production release, do not overwrite or delete immutable release
+tags or digests. Submit a new reviewed patch release that restores the last
+approved source or input pins, merge it normally, and use the same trusted
+workflow and provenance checks.
 
 Generated PRs use the workflow's short-lived `GITHUB_TOKEN`. Because GitHub
 leaves `pull_request` runs created by that token awaiting manual workflow

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/arm/mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/arm/mcp)
+[![SLSA Build Level 3](https://slsa.dev/images/gh-badge-level3.svg)](docs/slsa-build-level-3.md)
 
 # Arm MCP Server
 

--- a/docs/provenance-verification.md
+++ b/docs/provenance-verification.md
@@ -1,28 +1,20 @@
 # Verify Arm MCP Server image provenance
 
-Production releases of the Arm MCP Server publish a GitHub artifact
-attestation for the immutable digest of the final multi-architecture image.
-GitHub signs the provenance with a short-lived certificate obtained through
-GitHub OIDC and Sigstore, so the release process does not use a long-lived
-signing key.
+Verify a production release against the immutable image digest and source commit
+recorded in its GitHub Release. Do not resolve `latest` or another mutable tag
+for this check.
 
-## Expected identity
+Expected release identity:
 
 - Image: `docker.io/armlimited/arm-mcp`
 - Source repository: `arm/mcp`
-- Signer workflow: `arm/mcp/.github/workflows/build-mcp-image.yml`
+- Signer workflow: `arm/mcp/.github/workflows/trusted-mcp-release.yml`
 - Source ref: `refs/heads/main`
-- Event: a push of a reviewed release commit to `main`
 
-The GitHub Release records the released tag, immutable digest, source commit,
-and attestation URL. Use those values rather than resolving a mutable tag when
-verifying a release.
+## Verify through GitHub
 
-## Verify with GitHub CLI
-
-Install a current GitHub CLI with the `attestation` commands. Authenticate to
-Docker Hub if the registry requires it, then substitute the digest and source
-commit recorded in the GitHub Release:
+Open the release and copy its **Immutable digest** and **Source commit**, then
+run:
 
 ```bash
 DIGEST='sha256:replace-with-release-digest'
@@ -31,20 +23,22 @@ SOURCE_COMMIT='replace-with-release-source-commit'
 gh attestation verify \
   "oci://docker.io/armlimited/arm-mcp@${DIGEST}" \
   --repo arm/mcp \
-  --signer-workflow arm/mcp/.github/workflows/build-mcp-image.yml \
+  --signer-workflow arm/mcp/.github/workflows/trusted-mcp-release.yml \
   --source-ref refs/heads/main \
   --source-digest "${SOURCE_COMMIT}"
 ```
 
-A successful result verifies the Sigstore signature and GitHub OIDC identity,
-confirms that the attestation belongs to `arm/mcp`, enforces the approved
-workflow and `main` source ref, and matches the image's immutable digest and
-source commit. Add `--format json` to inspect the complete verification result.
+Success proves that GitHub verified a signed attestation for that exact image
+digest, produced from that exact `arm/mcp` commit on `main` by the trusted
+reusable release workflow.
 
-To fetch the copy attached to the image in Docker Hub instead of GitHub's
-artifact-attestation service, add `--bundle-from-oci` to the command.
+## Verify the registry bundle
 
-The build and provenance jobs run on ephemeral GitHub-hosted runners with
-job-scoped permissions. This establishes signed, digest-bound build provenance.
-A trusted reusable build boundary and assessment of the remaining SLSA Build
-Level 3 requirements are tracked separately.
+The same attestation bundle is attached to the image in Docker Hub. Verify that
+copy by rerunning the command with `--bundle-from-oci`.
+
+If verification fails, first confirm that the digest and commit were copied
+from the same GitHub Release, update GitHub CLI if it lacks the `attestation`
+commands, and authenticate to Docker Hub if registry access requires it. A
+signer, source, or digest mismatch should be treated as a failed verification,
+not bypassed.

--- a/docs/slsa-build-level-3.md
+++ b/docs/slsa-build-level-3.md
@@ -1,0 +1,33 @@
+# SLSA Build Level 3 for Arm MCP Server releases
+
+Arm MCP Server production images use GitHub's documented pattern for achieving
+SLSA v1.0 Build Level 3: the build and provenance generation run in a trusted
+reusable workflow using GitHub-hosted runners and GitHub artifact attestations.
+
+See the [SLSA v1.0 Build Level 3
+definition](https://slsa.dev/spec/v1.0/levels#build-l3-hardened-builds) and
+GitHub's guidance on [using reusable workflows and artifact attestations to
+achieve it](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/increase-security-rating).
+
+## Implementation
+
+- `.github/workflows/trusted-mcp-release.yml` owns the production AMD64 and
+  Arm64 builds, final image digest, and provenance generation.
+- GitHub-hosted runners isolate build executions. GitHub signs the provenance
+  through short-lived OIDC and Sigstore credentials that are not exposed to
+  build steps.
+- The attestation binds the released image digest to its source commit,
+  repository, and trusted workflow, and is published through GitHub and with
+  the image in Docker Hub.
+- Before promotion to `latest` or GitHub Release publication, the workflow
+  verifies the digest, repository, signer workflow, source branch, and source
+  commit.
+
+## Verification
+
+Follow [Verify Arm MCP Server image provenance](provenance-verification.md) to
+independently verify a released image and its trusted builder identity.
+
+This SLSA claim is limited to the production container image's build and
+provenance. It is not a broader assessment of vulnerabilities, dependencies,
+or other release-security controls.

--- a/mcp-local/tests/test_build_inputs.py
+++ b/mcp-local/tests/test_build_inputs.py
@@ -33,9 +33,13 @@ EMBEDDING_WORKFLOW = (
     REPOSITORY / ".github/workflows/build-embeddings.yml"
 ).read_text()
 IMAGE_WORKFLOW = (REPOSITORY / ".github/workflows/build-mcp-image.yml").read_text()
+TRUSTED_RELEASE_WORKFLOW = (
+    REPOSITORY / ".github/workflows/trusted-mcp-release.yml"
+).read_text()
 PROVENANCE_GUIDE = (
     REPOSITORY / "docs/provenance-verification.md"
 ).read_text()
+CODEOWNERS = (REPOSITORY / ".github/CODEOWNERS").read_text()
 PIN_WORKFLOWS = (TOOLCHAIN_WORKFLOW, INPUT_WORKFLOW, EMBEDDING_WORKFLOW)
 REQUIRED_CHECK_DISPATCH = (
     REPOSITORY / ".github/scripts/dispatch-required-pr-checks.sh"
@@ -144,7 +148,7 @@ def test_dockerfile_consumes_only_staged_third_party_inputs() -> None:
 
 
 def test_final_builds_do_not_acquire_inputs_live() -> None:
-    for workflow in (IMAGE_WORKFLOW, INTEGRATION_WORKFLOW):
+    for workflow in (TRUSTED_RELEASE_WORKFLOW, INTEGRATION_WORKFLOW):
         assert "stage-build-inputs.py" not in workflow
         assert "packages: read" in workflow
         assert "Log in to GHCR for locked build inputs" in workflow
@@ -166,24 +170,27 @@ def test_final_builds_disable_network_for_every_run_instruction() -> None:
         re.match(r"(?i:RUN)\s+--network=none(?:\s|$)", instruction)
         for instruction in run_instructions
     )
-    assert "          network: none\n" in IMAGE_WORKFLOW
+    assert "          network: none\n" in TRUSTED_RELEASE_WORKFLOW
     assert "            --network none \\\n" in INTEGRATION_WORKFLOW
 
 
 def test_release_build_loads_image_arguments_from_manifest() -> None:
-    assert 'lock_file="mcp-local/build-inputs.lock.json"' in IMAGE_WORKFLOW
-    assert "@sha256:[0-9a-f]{64}" in IMAGE_WORKFLOW
+    assert (
+        'lock_file="mcp-local/build-inputs.lock.json"'
+        in TRUSTED_RELEASE_WORKFLOW
+    )
+    assert "@sha256:[0-9a-f]{64}" in TRUSTED_RELEASE_WORKFLOW
     assert (
         "UBUNTU_IMAGE=${{ steps.locked_images.outputs.ubuntu_image }}"
-        in IMAGE_WORKFLOW
+        in TRUSTED_RELEASE_WORKFLOW
     )
     assert (
         "EMBEDDINGS_IMAGE=${{ steps.locked_images.outputs.embeddings_image }}"
-        in IMAGE_WORKFLOW
+        in TRUSTED_RELEASE_WORKFLOW
     )
     assert (
         "MCP_BUILD_INPUTS_IMAGE=${{ steps.locked_images.outputs.mcp_build_inputs_image }}"
-        in IMAGE_WORKFLOW
+        in TRUSTED_RELEASE_WORKFLOW
     )
 
 
@@ -214,40 +221,53 @@ def test_embedding_candidate_requires_reviewed_promotion_before_release() -> Non
 
 
 def test_release_uses_reviewed_server_version_without_self_merging() -> None:
-    assert "Validate reviewed release version" in IMAGE_WORKFLOW
+    assert "Validate proposed release version" in IMAGE_WORKFLOW
+    assert (
+        "Validate authorized release version and source"
+        in TRUSTED_RELEASE_WORKFLOW
+    )
     assert "github.event_name == 'push'" in IMAGE_WORKFLOW
-    assert 'version="$(jq -er' in IMAGE_WORKFLOW
+    assert 'version="$(jq -er' in TRUSTED_RELEASE_WORKFLOW
     assert "gh pr merge" not in IMAGE_WORKFLOW
+    assert "gh pr merge" not in TRUSTED_RELEASE_WORKFLOW
     assert "BUMP_BRANCH" not in IMAGE_WORKFLOW
     assert (
         "${{ env.IMAGE }}:${{ needs.validate-release.outputs.version }}-"
         "${{ matrix.tag }}"
-    ) in IMAGE_WORKFLOW
+    ) in TRUSTED_RELEASE_WORKFLOW
 
 
 def test_release_requires_runtime_egress_validation_for_both_architectures() -> None:
     validator = (MCP_LOCAL / "scripts/validate-runtime-egress.py").read_text()
 
-    assert "id: build" in IMAGE_WORKFLOW
-    assert 'image="${IMAGE}@${BUILD_DIGEST}"' in IMAGE_WORKFLOW
-    assert "validate-runtime-egress.py" in IMAGE_WORKFLOW
+    assert "runner: ubuntu-24.04" in TRUSTED_RELEASE_WORKFLOW
+    assert "platform: linux/amd64" in TRUSTED_RELEASE_WORKFLOW
+    assert "runner: ubuntu-24.04-arm" in TRUSTED_RELEASE_WORKFLOW
+    assert "platform: linux/arm64" in TRUSTED_RELEASE_WORKFLOW
+    assert "id: build" in TRUSTED_RELEASE_WORKFLOW
+    assert 'image="${IMAGE}@${BUILD_DIGEST}"' in TRUSTED_RELEASE_WORKFLOW
+    assert "validate-runtime-egress.py" in TRUSTED_RELEASE_WORKFLOW
     assert '"--network",\n        "none"' in validator
     assert ':/evidence"' not in validator
     assert 'runtime_trace.write_text(runtime.stderr' in validator
     assert 'negative_trace.write_text(negative.stderr' in validator
     assert '"output_channel": "docker stderr captured and persisted by host"' in validator
-    assert "runtime-egress-${{ matrix.tag }}" in IMAGE_WORKFLOW
-    assert "if-no-files-found: error" in IMAGE_WORKFLOW
-    assert "needs.build-arch-images.result == 'success'" in IMAGE_WORKFLOW
+    assert "runtime-egress-${{ matrix.tag }}" in TRUSTED_RELEASE_WORKFLOW
+    assert "if-no-files-found: error" in TRUSTED_RELEASE_WORKFLOW
+    assert "needs.build-arch-images.result == 'success'" in TRUSTED_RELEASE_WORKFLOW
 
 
 def test_release_manifest_uses_the_validated_architecture_digests() -> None:
-    publish_step = IMAGE_WORKFLOW.split(
-        "- name: Publish multi-architecture release", maxsplit=1
+    publish_step = TRUSTED_RELEASE_WORKFLOW.split(
+        "- name: Publish multi-architecture release from validated digests",
+        maxsplit=1,
     )[1].split("- name: Create tag and GitHub Release", maxsplit=1)[0]
 
-    assert "validated-image-digest-${{ matrix.tag }}-${{ github.run_id }}" in IMAGE_WORKFLOW
-    assert "actions/download-artifact@" in IMAGE_WORKFLOW
+    assert (
+        "validated-image-digest-${{ matrix.tag }}-${{ github.run_id }}"
+        in TRUSTED_RELEASE_WORKFLOW
+    )
+    assert "actions/download-artifact@" in TRUSTED_RELEASE_WORKFLOW
     assert "^sha256:[0-9a-f]{64}$" in publish_step
     assert '"${IMAGE}@${amd64_digest}"' in publish_step
     assert '"${IMAGE}@${arm64_digest}"' in publish_step
@@ -257,39 +277,53 @@ def test_release_manifest_uses_the_validated_architecture_digests() -> None:
 
 def test_runtime_egress_tracer_is_pinned_and_recorded_in_evidence() -> None:
     validator = (MCP_LOCAL / "scripts/validate-runtime-egress.py").read_text()
-    version_match = re.search(r"^  STRACE_VERSION: (\S+)$", IMAGE_WORKFLOW, re.MULTILINE)
+    version_match = re.search(
+        r"^  STRACE_VERSION: (\S+)$", TRUSTED_RELEASE_WORKFLOW, re.MULTILINE
+    )
 
     assert version_match
     version = version_match.group(1)
     assert re.fullmatch(r"[0-9][A-Za-z0-9.+:~-]*-[A-Za-z0-9.+~]+", version)
-    assert '"strace=${STRACE_VERSION}"' in IMAGE_WORKFLOW
-    assert "dpkg-query --show --showformat='${Version}' strace" in IMAGE_WORKFLOW
-    assert '--strace-package-version "${STRACE_PACKAGE_VERSION}"' in IMAGE_WORKFLOW
+    assert '"strace=${STRACE_VERSION}"' in TRUSTED_RELEASE_WORKFLOW
+    assert (
+        "dpkg-query --show --showformat='${Version}' strace"
+        in TRUSTED_RELEASE_WORKFLOW
+    )
+    assert (
+        '--strace-package-version "${STRACE_PACKAGE_VERSION}"'
+        in TRUSTED_RELEASE_WORKFLOW
+    )
     assert '"package_version": args.strace_package_version' in validator
 
 
 def test_release_attests_and_verifies_the_final_production_digest() -> None:
-    publish_image_job = IMAGE_WORKFLOW.split("  publish-image:", maxsplit=1)[
-        1
-    ].split("  verify-provenance:", maxsplit=1)[0]
-    publish_release_job = IMAGE_WORKFLOW.split(
+    publish_image_job = TRUSTED_RELEASE_WORKFLOW.split(
+        "  publish-image:", maxsplit=1
+    )[1].split("  attest-image:", maxsplit=1)[0]
+    publish_release_job = TRUSTED_RELEASE_WORKFLOW.split(
         "  publish-release:", maxsplit=1
     )[1]
-    attest_image_job = IMAGE_WORKFLOW.split("  attest-image:", maxsplit=1)[
-        1
-    ].split("  verify-provenance:", maxsplit=1)[0]
-    assert "IMAGE_FQDN: docker.io/armlimited/arm-mcp" in IMAGE_WORKFLOW
-    assert "attest-container-image.yml" not in IMAGE_WORKFLOW
-    assert "deployment-environment" not in IMAGE_WORKFLOW
+    attest_image_job = TRUSTED_RELEASE_WORKFLOW.split(
+        "  attest-image:", maxsplit=1
+    )[1].split("  verify-provenance:", maxsplit=1)[0]
+    assert (
+        "IMAGE_FQDN: docker.io/armlimited/arm-mcp"
+        in TRUSTED_RELEASE_WORKFLOW
+    )
+    assert "attest-container-image.yml" not in TRUSTED_RELEASE_WORKFLOW
+    assert "deployment-environment" not in TRUSTED_RELEASE_WORKFLOW
     assert (
         '--metadata-file "${RUNNER_TEMP}/manifest-metadata.json"'
-        in IMAGE_WORKFLOW
+        in TRUSTED_RELEASE_WORKFLOW
     )
     assert (
         '[[ ! "${created_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]'
-        in IMAGE_WORKFLOW
+        in TRUSTED_RELEASE_WORKFLOW
     )
-    assert '"${created_digest}" != "${inspected_digest}"' in IMAGE_WORKFLOW
+    assert (
+        '"${created_digest}" != "${inspected_digest}"'
+        in TRUSTED_RELEASE_WORKFLOW
+    )
     assert "runs-on: ubuntu-24.04" in attest_image_job
     assert "id-token: write" in attest_image_job
     assert "attestations: write" in attest_image_job
@@ -304,28 +338,42 @@ def test_release_attests_and_verifies_the_final_production_digest() -> None:
     )
     assert "push-to-registry: true" in attest_image_job
     assert "Validate attestation output" in attest_image_job
-    assert "verify-provenance:" in IMAGE_WORKFLOW
-    assert "attestations: read" in IMAGE_WORKFLOW
-    assert IMAGE_WORKFLOW.count("gh attestation verify") == 2
-    assert "--bundle-from-oci" in IMAGE_WORKFLOW
-    assert "needs.verify-provenance.result == 'success'" in IMAGE_WORKFLOW
+    assert "verify-provenance:" in TRUSTED_RELEASE_WORKFLOW
+    assert "attestations: read" in TRUSTED_RELEASE_WORKFLOW
+    assert TRUSTED_RELEASE_WORKFLOW.count("gh attestation verify") == 2
+    assert "--bundle-from-oci" in TRUSTED_RELEASE_WORKFLOW
+    assert (
+        "arm/mcp/.github/workflows/trusted-mcp-release.yml"
+        in TRUSTED_RELEASE_WORKFLOW
+    )
+    assert "packages: write" not in TRUSTED_RELEASE_WORKFLOW
+    assert (
+        "needs.verify-provenance.result == 'success'"
+        in TRUSTED_RELEASE_WORKFLOW
+    )
     assert '${IMAGE}:latest' not in publish_image_job
     assert "Promote verified image to latest" in publish_release_job
     assert '"${IMAGE_FQDN}@${DIGEST}"' in publish_release_job
     assert '--repo "${GITHUB_REPOSITORY}"' in publish_release_job
-    assert "Immutable digest:" in IMAGE_WORKFLOW
-    assert "verification instructions" in IMAGE_WORKFLOW
-    assert "blob/main/docs/provenance-verification.md" not in IMAGE_WORKFLOW
+    assert "Immutable digest:" in TRUSTED_RELEASE_WORKFLOW
+    assert "verification instructions" in TRUSTED_RELEASE_WORKFLOW
+    assert "SLSA Build Level 3:" in TRUSTED_RELEASE_WORKFLOW
     assert (
-        'blob/${SOURCE_SHA}/docs/provenance-verification.md'
-        in IMAGE_WORKFLOW
+        "blob/main/docs/provenance-verification.md"
+        not in TRUSTED_RELEASE_WORKFLOW
     )
+    assert (
+        'docs_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/'
+        '${SOURCE_SHA}/docs"' in TRUSTED_RELEASE_WORKFLOW
+    )
+    assert "${docs_url}/provenance-verification.md" in TRUSTED_RELEASE_WORKFLOW
+    assert "${docs_url}/slsa-build-level-3.md" in TRUSTED_RELEASE_WORKFLOW
 
 
 def test_provenance_guide_matches_the_enforced_release_identity() -> None:
     for expected in (
         "docker.io/armlimited/arm-mcp",
-        "arm/mcp/.github/workflows/build-mcp-image.yml",
+        "arm/mcp/.github/workflows/trusted-mcp-release.yml",
         "refs/heads/main",
         "--source-digest",
         "--bundle-from-oci",
@@ -334,6 +382,146 @@ def test_provenance_guide_matches_the_enforced_release_identity() -> None:
     assert not (
         REPOSITORY / ".github/workflows/attest-container-image.yml"
     ).exists()
+
+
+def test_release_controller_calls_only_the_trusted_release_implementation() -> None:
+    trusted_path = REPOSITORY / ".github/workflows/trusted-mcp-release.yml"
+    assert trusted_path.exists()
+    assert (
+        "  workflow_call:"
+        in TRUSTED_RELEASE_WORKFLOW.split("permissions:", maxsplit=1)[0]
+    )
+    assert (
+        IMAGE_WORKFLOW.count("uses: ./.github/workflows/trusted-mcp-release.yml") == 2
+    )
+    assert "release_mode: dry-run" in IMAGE_WORKFLOW
+    assert "release_mode: production" in IMAGE_WORKFLOW
+
+    for production_command in (
+        "docker buildx imagetools create",
+        "actions/attest@",
+        "gh attestation verify",
+        "gh release create",
+        "Log in to Docker Hub",
+    ):
+        assert production_command not in IMAGE_WORKFLOW
+
+
+def test_release_calls_have_distinct_authorization_permissions_and_secrets() -> None:
+    dry_run_call = IMAGE_WORKFLOW.split("  dry-run:", maxsplit=1)[1].split(
+        "  production:", maxsplit=1
+    )[0]
+    production_call = IMAGE_WORKFLOW.split("  production:", maxsplit=1)[1]
+
+    for expected in (
+        "github.repository == 'arm/mcp'",
+        "github.event_name == 'push'",
+        "github.ref == 'refs/heads/main'",
+        "github.ref_type == 'branch'",
+        "github.ref_protected == true",
+        "github.sha == github.event.after",
+    ):
+        assert expected in production_call
+
+    assert "release_mode: dry-run" in dry_run_call
+    assert "actions: read" in dry_run_call
+    assert "contents: read" in dry_run_call
+    assert "packages: read" in dry_run_call
+    assert "secrets:" not in dry_run_call
+    for forbidden in (
+        "contents: write",
+        "id-token: write",
+        "attestations: write",
+        "artifact-metadata: write",
+        "DOCKERHUB_USERNAME",
+        "DOCKERHUB_TOKEN",
+    ):
+        assert forbidden not in dry_run_call
+
+    assert "DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}" in production_call
+    assert "DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}" in production_call
+    assert "secrets: inherit" not in IMAGE_WORKFLOW
+    assert "secrets: inherit" not in TRUSTED_RELEASE_WORKFLOW
+    assert "environment:" not in IMAGE_WORKFLOW
+    assert "environment:" not in TRUSTED_RELEASE_WORKFLOW
+
+
+def test_trusted_release_reauthorizes_the_original_caller_and_fails_closed() -> None:
+    authorization = TRUSTED_RELEASE_WORKFLOW.split("  authorize:", maxsplit=1)[1].split(
+        "  validate-release:", maxsplit=1
+    )[0]
+    for expected in (
+        "CALLER_REPOSITORY: ${{ github.repository }}",
+        "CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}",
+        "CALLER_EVENT: ${{ github.event_name }}",
+        "CALLER_REF: ${{ github.ref }}",
+        "CALLER_REF_TYPE: ${{ github.ref_type }}",
+        "CALLER_REF_PROTECTED: ${{ github.ref_protected }}",
+        "CALLER_SHA: ${{ github.sha }}",
+        "PUSH_AFTER: ${{ github.event.after }}",
+        "DISPATCH_ACTION: ${{ github.event.inputs.release_action }}",
+        'REQUESTED_MODE}" = "production',
+        'CALLER_WORKFLOW_REF}" = "arm/mcp/.github/workflows/build-mcp-image.yml@refs/heads/main',
+        'REQUESTED_MODE}" = "dry-run',
+        'DISPATCH_ACTION}" = "dry-run',
+        "Unauthorized trusted release invocation",
+        "exit 1",
+    ):
+        assert expected in authorization
+
+    assert (
+        "needs: authorize"
+        in TRUSTED_RELEASE_WORKFLOW.split("  validate-release:", maxsplit=1)[1].split(
+            "  build-arch-images:", maxsplit=1
+        )[0]
+    )
+    assert (
+        "needs: validate-release"
+        in TRUSTED_RELEASE_WORKFLOW.split("  build-arch-images:", maxsplit=1)[1].split(
+            "  record-dry-run:", maxsplit=1
+        )[0]
+    )
+    assert (
+        "needs: publish-image"
+        in TRUSTED_RELEASE_WORKFLOW.split("  attest-image:", maxsplit=1)[1].split(
+            "  verify-provenance:", maxsplit=1
+        )[0]
+    )
+    assert (
+        "verify-provenance"
+        in TRUSTED_RELEASE_WORKFLOW.split("  publish-release:", maxsplit=1)[1]
+    )
+
+
+def test_production_release_actions_are_immutably_pinned() -> None:
+    external_actions = re.findall(
+        r"^\s*uses:\s+([^\s#]+)", TRUSTED_RELEASE_WORKFLOW, re.MULTILINE
+    )
+    assert external_actions
+    assert all(
+        re.fullmatch(r"[^@]+@[0-9a-f]{40}", action) for action in external_actions
+    )
+
+
+def test_codeowners_covers_release_sensitive_workflows_and_inputs() -> None:
+    for protected_path in (
+        "/.github/workflows/",
+        "/.github/scripts/",
+        "/mcp-local/Dockerfile ",
+        "/mcp-local/Dockerfile.inputs ",
+        "/mcp-local/server.json ",
+        "/mcp-local/build-inputs.lock.json ",
+        "/mcp-local/pyproject.toml ",
+        "/mcp-local/uv.lock ",
+        "/embedding-generation/Dockerfile.acquire ",
+        "/embedding-generation/Dockerfile.toolchain ",
+        "/embedding-generation/Dockerfile.vectorstore ",
+        "/embedding-generation/embedding-model.lock.json ",
+        "/embedding-generation/pipeline-inputs.lock.json ",
+        "/embedding-generation/pyproject.toml ",
+        "/embedding-generation/uv.lock ",
+    ):
+        assert protected_path in CODEOWNERS
 
 
 def test_manual_release_proposals_support_all_release_types() -> None:

--- a/mcp-local/tests/test_build_inputs.py
+++ b/mcp-local/tests/test_build_inputs.py
@@ -425,18 +425,31 @@ def test_release_calls_have_distinct_authorization_permissions_and_secrets() -> 
 
     assert "release_mode: dry-run" in dry_run_call
     assert "actions: read" in dry_run_call
-    assert "contents: read" in dry_run_call
+    assert "contents: write" in dry_run_call
     assert "packages: read" in dry_run_call
+    assert "id-token: write" in dry_run_call
+    assert "attestations: write" in dry_run_call
+    assert "artifact-metadata: write" in dry_run_call
     assert "secrets:" not in dry_run_call
     for forbidden in (
-        "contents: write",
-        "id-token: write",
-        "attestations: write",
-        "artifact-metadata: write",
         "DOCKERHUB_USERNAME",
         "DOCKERHUB_TOKEN",
     ):
         assert forbidden not in dry_run_call
+
+    for job_start, job_end in (
+        ("  authorize:", "  validate-release:"),
+        ("  validate-release:", "  build-arch-images:"),
+        ("  build-arch-images:", "  record-dry-run:"),
+        ("  record-dry-run:", "  publish-image:"),
+    ):
+        dry_run_job = TRUSTED_RELEASE_WORKFLOW.split(job_start, maxsplit=1)[1].split(
+            job_end, maxsplit=1
+        )[0]
+        assert "contents: write" not in dry_run_job
+        assert "id-token: write" not in dry_run_job
+        assert "attestations: write" not in dry_run_job
+        assert "artifact-metadata: write" not in dry_run_job
 
     assert "DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}" in production_call
     assert "DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}" in production_call


### PR DESCRIPTION
### Summary
Addresses the remaining parts of STESOL-581 and STESOL-582.
- Moves production image builds, publication, and provenance into a trusted reusable workflow.
- Restricts releases to the approved protected-main caller with least-privilege permissions.
- Verifies the final image digest and GitHub/OCI provenance before release publication.
- Documents SLSA Build Level 3 implementation and verification.
- Adds a SLSA Build Level 3 badge to the README.

Dry run was successful: https://github.com/arm/mcp/actions/runs/32989309714