### PR TITLE
Reuse BM25 results within hybrid search

### DIFF
--- a/arm_kb_search/search.py
+++ b/arm_kb_search/search.py
@@ -232,6 +232,15 @@ def lexical_prepass_search(
     """Return high-exactness lexical candidates before dense retrieval is merged."""
     prepass_depth = max(k, candidate_depth)
     candidates = bm25_search(query, metadata, bm25_index, prepass_depth)
+    return _rank_lexical_candidates(query, candidates, k)
+
+
+def _rank_lexical_candidates(
+    query: str,
+    candidates: List[Dict[str, Any]],
+    k: int,
+) -> List[Dict[str, Any]]:
+    """Rank already retrieved BM25 candidates without rescoring the corpus."""
     if not candidates:
         return []
     scored_candidates: List[Dict[str, Any]] = []
@@ -523,15 +532,17 @@ def hybrid_search(
     candidate_depth: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     candidate_depth = candidate_depth or max(k * 20, 100)
-    lexical_results = lexical_prepass_search(
+    lexical_k = max(k * 3, PINNED_LEXICAL_CANDIDATES)
+    # Score and sort once at the depth required by both lexical consumers.
+    bm25_results = bm25_search(
         query,
         metadata,
         bm25_index,
-        k=max(k * 3, PINNED_LEXICAL_CANDIDATES),
-        candidate_depth=max(candidate_depth, LEXICAL_PREPASS_DEPTH),
+        k=max(candidate_depth, LEXICAL_PREPASS_DEPTH, lexical_k),
     )
+    lexical_results = _rank_lexical_candidates(query, bm25_results, lexical_k)
     dense_results = embedding_search(query, usearch_index, metadata, embedding_model, candidate_depth)
-    sparse_results = bm25_search(query, metadata, bm25_index, candidate_depth)
+    sparse_results = bm25_results[:candidate_depth]
 
     candidates: Dict[str, Dict[str, Any]] = {}
     for result in lexical_results:

--- a/arm_kb_search/search.py
+++ b/arm_kb_search/search.py
@@ -240,7 +240,7 @@ def _rank_lexical_candidates(
     candidates: List[Dict[str, Any]],
     k: int,
 ) -> List[Dict[str, Any]]:
-    """Rank already retrieved BM25 candidates without rescoring the corpus."""
+    """Apply lexical prepass scoring to existing results without recomputing BM25."""
     if not candidates:
         return []
     scored_candidates: List[Dict[str, Any]] = []
@@ -532,17 +532,25 @@ def hybrid_search(
     candidate_depth: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     candidate_depth = candidate_depth or max(k * 20, 100)
-    lexical_k = max(k * 3, PINNED_LEXICAL_CANDIDATES)
-    # Score and sort once at the depth required by both lexical consumers.
+    lexical_limit = max(k * 3, PINNED_LEXICAL_CANDIDATES)
+    bm25_depth = max(candidate_depth, LEXICAL_PREPASS_DEPTH, lexical_limit)
+
+    # Share one BM25 ranking between the lexical prepass and sparse search.
     bm25_results = bm25_search(
         query,
         metadata,
         bm25_index,
-        k=max(candidate_depth, LEXICAL_PREPASS_DEPTH, lexical_k),
+        k=bm25_depth,
     )
-    lexical_results = _rank_lexical_candidates(query, bm25_results, lexical_k)
-    dense_results = embedding_search(query, usearch_index, metadata, embedding_model, candidate_depth)
+
+    lexical_results = _rank_lexical_candidates(
+        query, bm25_results, k=lexical_limit
+    )
     sparse_results = bm25_results[:candidate_depth]
+
+    dense_results = embedding_search(
+        query, usearch_index, metadata, embedding_model, candidate_depth
+    )
 
     candidates: Dict[str, Dict[str, Any]] = {}
     for result in lexical_results:

--- a/mcp-local/uv.lock
+++ b/mcp-local/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "arm-kb-search"
-version = "0.3.0"
+version = "0.3.1"
 source = { directory = "../" }
 dependencies = [
     { name = "numkong" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arm-kb-search"
-version = "0.3.0"
+version = "0.3.1"
 requires-python = ">=3.10"
 dependencies = [
   "numpy",


### PR DESCRIPTION
Hybrid search currently scores and sorts the same BM25 query twice: once inside the lexical prepass and again for sparse retrieval. Retrieve one result list at the depth required by both paths, reuse it for lexical reranking, and slice it for sparse retrieval.

Extract the existing lexical ranking logic into a helper so standalone lexical prepass calls keep their behavior. Preserve candidate limits and the existing merging and final ranking rules.

Increase the independent arm-kb-search package version to 0.3.1
