### PR TITLE
Add production env gate and create action for withdrawing release

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,8 @@ jobs:
           uv run --directory mcp-local --locked --only-group test \
             pytest -q \
             tests/test_build_inputs.py \
-            tests/test_invocation_logger.py
+            tests/test_invocation_logger.py \
+            tests/test_release_withdrawal.py
 
   integration-tests:
     strategy:

--- a/.github/workflows/trusted-mcp-release.yml
+++ b/.github/workflows/trusted-mcp-release.yml
@@ -144,8 +144,31 @@ jobs:
             echo "Manual dry runs build and validate the selected commit but never publish." >> "${GITHUB_STEP_SUMMARY}"
           fi
 
-  build-arch-images:
+  production-gate:
+    name: Approve production release
     needs: validate-release
+    if: ${{ needs.validate-release.outputs.mode == 'production' }}
+    runs-on: ubuntu-24.04
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - name: Record production approval
+        run: echo "Production release approved." >> "${GITHUB_STEP_SUMMARY}"
+
+  build-arch-images:
+    needs:
+      - validate-release
+      - production-gate
+    if: >-
+      ${{
+        always()
+        && needs.validate-release.result == 'success'
+        && (
+          needs.validate-release.outputs.mode == 'dry-run'
+          || needs.production-gate.result == 'success'
+        )
+      }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/withdraw-mcp-release.yml
+++ b/.github/workflows/withdraw-mcp-release.yml
@@ -51,6 +51,7 @@ jobs:
         id: validate
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           WITHDRAW_VERSION: ${{ inputs.withdraw_version }}
           RESTORE_VERSION: ${{ inputs.restore_version }}
           CONFIRMATION: ${{ inputs.confirmation }}
@@ -68,10 +69,20 @@ jobs:
               --format '{{json .Manifest}}' | jq -er '.digest'
           }
 
-          withdraw_digest="$(digest "${IMAGE_FQDN}:${WITHDRAW_VERSION}")"
+          gh release view "v${RESTORE_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" > /dev/null
+
           restore_digest="$(digest "${IMAGE_FQDN}:${RESTORE_VERSION}")"
           latest_digest="$(digest "${IMAGE_FQDN}:latest")"
-          [ "${latest_digest}" = "${withdraw_digest}" ]
+          withdraw_digest="$(
+            digest "${IMAGE_FQDN}:${WITHDRAW_VERSION}" 2>/dev/null || true
+          )"
+          if [ -n "${withdraw_digest}" ]; then
+            [ "${latest_digest}" = "${withdraw_digest}" ] ||
+              [ "${latest_digest}" = "${restore_digest}" ]
+          else
+            [ "${latest_digest}" = "${restore_digest}" ]
+          fi
 
           echo "restore_digest=${restore_digest}" >> "${GITHUB_OUTPUT}"
 
@@ -140,8 +151,16 @@ jobs:
           set -euo pipefail
           gh release edit "v${RESTORE_VERSION}" \
             --repo "${GITHUB_REPOSITORY}" --latest
-          gh release delete "v${WITHDRAW_VERSION}" \
-            --repo "${GITHUB_REPOSITORY}" --cleanup-tag --yes
+          if gh release view "v${WITHDRAW_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" > /dev/null 2>&1; then
+            gh release delete "v${WITHDRAW_VERSION}" \
+              --repo "${GITHUB_REPOSITORY}" --yes
+          fi
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${WITHDRAW_VERSION}" \
+            > /dev/null 2>&1; then
+            gh api --method DELETE \
+              "repos/${GITHUB_REPOSITORY}/git/refs/tags/v${WITHDRAW_VERSION}"
+          fi
 
           {
             echo "### Withdrawn v${WITHDRAW_VERSION}"

--- a/.github/workflows/withdraw-mcp-release.yml
+++ b/.github/workflows/withdraw-mcp-release.yml
@@ -1,0 +1,152 @@
+name: Withdraw MCP Release
+
+run-name: Withdraw v${{ inputs.withdraw_version }} to v${{ inputs.restore_version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      withdraw_version:
+        description: Version to withdraw (without v)
+        required: true
+        type: string
+      restore_version:
+        description: Version to restore as latest (without v)
+        required: true
+        type: string
+      confirmation:
+        description: Type WITHDRAW <version> TO <version>
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# Do not update latest while a production release is doing the same.
+concurrency:
+  group: build-mcp-image-publish
+  cancel-in-progress: false
+
+env:
+  IMAGE: armlimited/arm-mcp
+  IMAGE_FQDN: docker.io/armlimited/arm-mcp
+
+jobs:
+  withdraw:
+    if: ${{ github.repository == 'arm/mcp' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-24.04
+    environment: production
+    permissions:
+      contents: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Validate withdrawal
+        id: validate
+        shell: bash
+        env:
+          WITHDRAW_VERSION: ${{ inputs.withdraw_version }}
+          RESTORE_VERSION: ${{ inputs.restore_version }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          version_pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
+          [[ "${WITHDRAW_VERSION}" =~ ${version_pattern} ]]
+          [[ "${RESTORE_VERSION}" =~ ${version_pattern} ]]
+          [ "${WITHDRAW_VERSION}" != "${RESTORE_VERSION}" ]
+          [ "${CONFIRMATION}" = \
+            "WITHDRAW ${WITHDRAW_VERSION} TO ${RESTORE_VERSION}" ]
+
+          digest() {
+            docker buildx imagetools inspect "$1" \
+              --format '{{json .Manifest}}' | jq -er '.digest'
+          }
+
+          withdraw_digest="$(digest "${IMAGE_FQDN}:${WITHDRAW_VERSION}")"
+          restore_digest="$(digest "${IMAGE_FQDN}:${RESTORE_VERSION}")"
+          latest_digest="$(digest "${IMAGE_FQDN}:latest")"
+          [ "${latest_digest}" = "${withdraw_digest}" ]
+
+          echo "restore_digest=${restore_digest}" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore latest
+        shell: bash
+        env:
+          RESTORE_DIGEST: ${{ steps.validate.outputs.restore_digest }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE_FQDN}:latest" \
+            "${IMAGE_FQDN}@${RESTORE_DIGEST}"
+          test "$(
+            docker buildx imagetools inspect "${IMAGE_FQDN}:latest" \
+              --format '{{json .Manifest}}' | jq -er '.digest'
+          )" = "${RESTORE_DIGEST}"
+
+      - name: Delete withdrawn Docker tags
+        shell: bash
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          WITHDRAW_VERSION: ${{ inputs.withdraw_version }}
+        run: |
+          set -euo pipefail
+          hub_token="$(
+            curl --fail --silent --show-error \
+              --request POST \
+              --header 'Content-Type: application/json' \
+              --data "$(jq -n \
+                --arg identifier "${DOCKERHUB_USERNAME}" \
+                --arg secret "${DOCKERHUB_TOKEN}" \
+                '{identifier: $identifier, secret: $secret}')" \
+              https://hub.docker.com/v2/auth/token |
+              jq -er '.access_token'
+          )"
+          echo "::add-mask::${hub_token}"
+
+          for tag in \
+            "${WITHDRAW_VERSION}" \
+            "${WITHDRAW_VERSION}-amd64" \
+            "${WITHDRAW_VERSION}-arm64"; do
+            status="$(curl --silent --show-error \
+              --output "${RUNNER_TEMP}/docker-delete-response" \
+              --write-out '%{http_code}' \
+              --request DELETE \
+              --header "Authorization: Bearer ${hub_token}" \
+              "https://hub.docker.com/v2/namespaces/armlimited/repositories/arm-mcp/tags/${tag}")"
+            case "${status}" in
+              202|204|404) ;;
+              *)
+                cat "${RUNNER_TEMP}/docker-delete-response"
+                echo "::error::Failed to delete ${IMAGE}:${tag} (HTTP ${status})."
+                exit 1
+                ;;
+            esac
+          done
+
+      - name: Withdraw GitHub release and tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WITHDRAW_VERSION: ${{ inputs.withdraw_version }}
+          RESTORE_VERSION: ${{ inputs.restore_version }}
+        run: |
+          set -euo pipefail
+          gh release edit "v${RESTORE_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" --latest
+          gh release delete "v${WITHDRAW_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" --cleanup-tag --yes
+
+          {
+            echo "### Withdrawn v${WITHDRAW_VERSION}"
+            echo
+            echo "- Docker \`latest\` now points to \`v${RESTORE_VERSION}\`."
+            echo "- Docker tags for \`v${WITHDRAW_VERSION}\` were deleted."
+            echo "- GitHub release and tag \`v${WITHDRAW_VERSION}\` were deleted."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/withdraw-mcp-release.yml
+++ b/.github/workflows/withdraw-mcp-release.yml
@@ -69,8 +69,10 @@ jobs:
               --format '{{json .Manifest}}' | jq -er '.digest'
           }
 
-          gh release view "v${RESTORE_VERSION}" \
-            --repo "${GITHUB_REPOSITORY}" > /dev/null
+          for version in "${WITHDRAW_VERSION}" "${RESTORE_VERSION}"; do
+            gh release view "v${version}" \
+              --repo "${GITHUB_REPOSITORY}" > /dev/null
+          done
 
           restore_digest="$(digest "${IMAGE_FQDN}:${RESTORE_VERSION}")"
           latest_digest="$(digest "${IMAGE_FQDN}:latest")"
@@ -141,7 +143,7 @@ jobs:
             esac
           done
 
-      - name: Withdraw GitHub release and tag
+      - name: Mark GitHub release withdrawn
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -151,21 +153,28 @@ jobs:
           set -euo pipefail
           gh release edit "v${RESTORE_VERSION}" \
             --repo "${GITHUB_REPOSITORY}" --latest
-          if gh release view "v${WITHDRAW_VERSION}" \
-            --repo "${GITHUB_REPOSITORY}" > /dev/null 2>&1; then
-            gh release delete "v${WITHDRAW_VERSION}" \
-              --repo "${GITHUB_REPOSITORY}" --yes
+
+          marker='<!-- arm-mcp-withdrawn -->'
+          notes="$(gh release view "v${WITHDRAW_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --json body --jq '.body // ""')"
+          if [[ "${notes}" != *"${marker}"* ]]; then
+            printf -v notes \
+              '%s\n> This release has been withdrawn, and its Docker images are no longer available.\n>\n> Use v%s until a replacement is published.\n\n%s' \
+              "${marker}" "${RESTORE_VERSION}" "${notes}"
           fi
-          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/v${WITHDRAW_VERSION}" \
-            > /dev/null 2>&1; then
-            gh api --method DELETE \
-              "repos/${GITHUB_REPOSITORY}/git/refs/tags/v${WITHDRAW_VERSION}"
-          fi
+
+          gh release edit "v${WITHDRAW_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "v${WITHDRAW_VERSION} — WITHDRAWN" \
+            --notes "${notes}" \
+            --latest=false
 
           {
             echo "### Withdrawn v${WITHDRAW_VERSION}"
             echo
             echo "- Docker \`latest\` now points to \`v${RESTORE_VERSION}\`."
             echo "- Docker tags for \`v${WITHDRAW_VERSION}\` were deleted."
-            echo "- GitHub release and tag \`v${WITHDRAW_VERSION}\` were deleted."
+            echo "- GitHub release \`v${WITHDRAW_VERSION}\` was marked withdrawn."
+            echo "- Git tag \`v${WITHDRAW_VERSION}\` was retained."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/release-withdrawal.md
+++ b/docs/release-withdrawal.md
@@ -22,6 +22,9 @@ The workflow checks that `latest` is currently the withdrawn image, moves
 Docker tags, marks the fallback GitHub release as latest, and deletes the
 withdrawn GitHub release and tag.
 
+The workflow can be rerun if an earlier attempt only completed some of these
+steps.
+
 Leave `main` at the withdrawn version; that version is used and must not be
 republished. Choose the next version according to the reason for the withdrawal.
 For example, skip to the next minor version with:

--- a/docs/release-withdrawal.md
+++ b/docs/release-withdrawal.md
@@ -19,8 +19,9 @@ gh workflow run withdraw-mcp-release.yml \
 
 The workflow checks that `latest` is currently the withdrawn image, moves
 `latest` to the fallback image, deletes the version and architecture-specific
-Docker tags, marks the fallback GitHub release as latest, and deletes the
-withdrawn GitHub release and tag.
+Docker tags, and marks the fallback GitHub release as latest. It retains the Git
+tag and marks the GitHub release as withdrawn while preserving its original
+notes.
 
 The workflow can be rerun if an earlier attempt only completed some of these
 steps.

--- a/docs/release-withdrawal.md
+++ b/docs/release-withdrawal.md
@@ -1,0 +1,42 @@
+# Withdrawing an MCP release
+
+The **Withdraw MCP Release** workflow removes an unintended public release. It
+does not modify `main` or change the version in `mcp-local/server.json`.
+
+The `DOCKERHUB_TOKEN` must have read, write, and delete access to
+`armlimited/arm-mcp`.
+
+For example, to withdraw `4.2.0` and restore `4.1.0`:
+
+```bash
+gh workflow run withdraw-mcp-release.yml \
+  --repo arm/mcp \
+  --ref main \
+  -f withdraw_version=4.2.0 \
+  -f restore_version=4.1.0 \
+  -f confirmation='WITHDRAW 4.2.0 TO 4.1.0'
+```
+
+The workflow checks that `latest` is currently the withdrawn image, moves
+`latest` to the fallback image, deletes the version and architecture-specific
+Docker tags, marks the fallback GitHub release as latest, and deletes the
+withdrawn GitHub release and tag.
+
+Leave `main` at the withdrawn version; that version is used and must not be
+republished. Choose the next version according to the reason for the withdrawal.
+For example, skip to the next minor version with:
+
+```bash
+gh workflow run build-mcp-image.yml \
+  --repo arm/mcp \
+  --ref main \
+  -f release_action=minor
+```
+
+Use `hotfix` or `major` instead when that is the appropriate next version.
+
+## Suspected malicious release
+
+This workflow does not cover releases involving suspected malicious code or a
+repository or credential compromise. Follow the security incident response
+process instead.

--- a/mcp-local/tests/test_build_inputs.py
+++ b/mcp-local/tests/test_build_inputs.py
@@ -456,7 +456,29 @@ def test_release_calls_have_distinct_authorization_permissions_and_secrets() -> 
     assert "secrets: inherit" not in IMAGE_WORKFLOW
     assert "secrets: inherit" not in TRUSTED_RELEASE_WORKFLOW
     assert "environment:" not in IMAGE_WORKFLOW
-    assert "environment:" not in TRUSTED_RELEASE_WORKFLOW
+
+
+def test_production_environment_approval_precedes_first_registry_push() -> None:
+    gate_job = TRUSTED_RELEASE_WORKFLOW.split(
+        "  production-gate:", maxsplit=1
+    )[1].split("  build-arch-images:", maxsplit=1)[0]
+    build_job = TRUSTED_RELEASE_WORKFLOW.split(
+        "  build-arch-images:", maxsplit=1
+    )[1].split("  record-dry-run:", maxsplit=1)[0]
+
+    assert "needs: validate-release" in gate_job
+    assert "outputs.mode == 'production'" in gate_job
+    assert "environment: production" in gate_job
+    assert "- production-gate" in build_job
+    assert "needs.production-gate.result == 'success'" in build_job
+    assert "needs.validate-release.outputs.mode == 'dry-run'" in build_job
+
+    gate_position = TRUSTED_RELEASE_WORKFLOW.index("  production-gate:")
+    first_dockerhub_login = TRUSTED_RELEASE_WORKFLOW.index("Log in to Docker Hub")
+    first_registry_push = TRUSTED_RELEASE_WORKFLOW.index(
+        "push: ${{ needs.validate-release.outputs.mode == 'production' }}"
+    )
+    assert gate_position < first_dockerhub_login < first_registry_push
 
 
 def test_trusted_release_reauthorizes_the_original_caller_and_fails_closed() -> None:
@@ -488,12 +510,11 @@ def test_trusted_release_reauthorizes_the_original_caller_and_fails_closed() -> 
             "  build-arch-images:", maxsplit=1
         )[0]
     )
-    assert (
-        "needs: validate-release"
-        in TRUSTED_RELEASE_WORKFLOW.split("  build-arch-images:", maxsplit=1)[1].split(
-            "  record-dry-run:", maxsplit=1
-        )[0]
-    )
+    build_job = TRUSTED_RELEASE_WORKFLOW.split(
+        "  build-arch-images:", maxsplit=1
+    )[1].split("  record-dry-run:", maxsplit=1)[0]
+    assert "- validate-release" in build_job
+    assert "- production-gate" in build_job
     assert (
         "needs: publish-image"
         in TRUSTED_RELEASE_WORKFLOW.split("  attest-image:", maxsplit=1)[1].split(

--- a/mcp-local/tests/test_release_withdrawal.py
+++ b/mcp-local/tests/test_release_withdrawal.py
@@ -21,22 +21,31 @@ def test_withdrawal_is_manual_guarded_and_serialized() -> None:
 
 
 def test_latest_is_restored_before_release_tags_are_deleted() -> None:
-    preflight = WORKFLOW.index('gh release view "v${RESTORE_VERSION}"')
+    preflight = WORKFLOW.index(
+        'for version in "${WITHDRAW_VERSION}" "${RESTORE_VERSION}"'
+    )
     restore = WORKFLOW.index("- name: Restore latest")
     delete_docker = WORKFLOW.index("- name: Delete withdrawn Docker tags")
-    delete_github = WORKFLOW.index("- name: Withdraw GitHub release and tag")
+    edit_github = WORKFLOW.index("- name: Mark GitHub release withdrawn")
 
-    assert preflight < restore < delete_docker < delete_github
+    assert preflight < restore < delete_docker < edit_github
     assert '"${WITHDRAW_VERSION}-amd64"' in WORKFLOW
     assert '"${WITHDRAW_VERSION}-arm64"' in WORKFLOW
-    assert 'git/refs/tags/v${WITHDRAW_VERSION}' in WORKFLOW
 
 
 def test_withdrawal_can_resume_after_latest_or_tags_were_updated() -> None:
     assert 'digest "${IMAGE_FQDN}:${WITHDRAW_VERSION}" 2>/dev/null || true' in WORKFLOW
     assert '"${latest_digest}" = "${restore_digest}"' in WORKFLOW
-    assert 'if gh release view "v${WITHDRAW_VERSION}"' in WORKFLOW
+    assert "<!-- arm-mcp-withdrawn -->" in WORKFLOW
     assert "202|204|404" in WORKFLOW
+
+
+def test_withdrawn_release_and_git_tag_are_retained() -> None:
+    assert "gh release delete" not in WORKFLOW
+    assert 'git/refs/tags/v${WITHDRAW_VERSION}' not in WORKFLOW
+    assert "--latest=false" in WORKFLOW
+    assert "its Docker images are no longer available" in WORKFLOW
+    assert "--json body" in WORKFLOW
 
 
 def test_workflow_does_not_change_main_and_runbook_covers_compromise() -> None:

--- a/mcp-local/tests/test_release_withdrawal.py
+++ b/mcp-local/tests/test_release_withdrawal.py
@@ -21,14 +21,22 @@ def test_withdrawal_is_manual_guarded_and_serialized() -> None:
 
 
 def test_latest_is_restored_before_release_tags_are_deleted() -> None:
+    preflight = WORKFLOW.index('gh release view "v${RESTORE_VERSION}"')
     restore = WORKFLOW.index("- name: Restore latest")
     delete_docker = WORKFLOW.index("- name: Delete withdrawn Docker tags")
     delete_github = WORKFLOW.index("- name: Withdraw GitHub release and tag")
 
-    assert restore < delete_docker < delete_github
+    assert preflight < restore < delete_docker < delete_github
     assert '"${WITHDRAW_VERSION}-amd64"' in WORKFLOW
     assert '"${WITHDRAW_VERSION}-arm64"' in WORKFLOW
-    assert "--cleanup-tag --yes" in WORKFLOW
+    assert 'git/refs/tags/v${WITHDRAW_VERSION}' in WORKFLOW
+
+
+def test_withdrawal_can_resume_after_latest_or_tags_were_updated() -> None:
+    assert 'digest "${IMAGE_FQDN}:${WITHDRAW_VERSION}" 2>/dev/null || true' in WORKFLOW
+    assert '"${latest_digest}" = "${restore_digest}"' in WORKFLOW
+    assert 'if gh release view "v${WITHDRAW_VERSION}"' in WORKFLOW
+    assert "202|204|404" in WORKFLOW
 
 
 def test_workflow_does_not_change_main_and_runbook_covers_compromise() -> None:

--- a/mcp-local/tests/test_release_withdrawal.py
+++ b/mcp-local/tests/test_release_withdrawal.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).resolve().parents[2]
+WORKFLOW = (
+    REPOSITORY / ".github/workflows/withdraw-mcp-release.yml"
+).read_text(encoding="utf-8")
+RUNBOOK = (REPOSITORY / "docs/release-withdrawal.md").read_text(encoding="utf-8")
+
+
+def test_withdrawal_is_manual_guarded_and_serialized() -> None:
+    triggers = WORKFLOW.split("permissions:", maxsplit=1)[0]
+
+    assert "workflow_dispatch:" in triggers
+    assert "pull_request:" not in triggers
+    assert "push:" not in triggers
+    assert "environment: production" in WORKFLOW
+    assert "group: build-mcp-image-publish" in WORKFLOW
+    assert '"WITHDRAW ${WITHDRAW_VERSION} TO ${RESTORE_VERSION}"' in WORKFLOW
+    assert '"${WITHDRAW_VERSION}" != "${RESTORE_VERSION}"' in WORKFLOW
+
+
+def test_latest_is_restored_before_release_tags_are_deleted() -> None:
+    restore = WORKFLOW.index("- name: Restore latest")
+    delete_docker = WORKFLOW.index("- name: Delete withdrawn Docker tags")
+    delete_github = WORKFLOW.index("- name: Withdraw GitHub release and tag")
+
+    assert restore < delete_docker < delete_github
+    assert '"${WITHDRAW_VERSION}-amd64"' in WORKFLOW
+    assert '"${WITHDRAW_VERSION}-arm64"' in WORKFLOW
+    assert "--cleanup-tag --yes" in WORKFLOW
+
+
+def test_workflow_does_not_change_main_and_runbook_covers_compromise() -> None:
+    assert "git push" not in WORKFLOW
+    assert "git reset" not in WORKFLOW
+    assert "does not modify `main`" in RUNBOOK
+    assert "Suspected malicious release" in RUNBOOK


### PR DESCRIPTION
- Gate production releases behind approval from the production environment.
- Add a manual workflow to withdraw an MCP release by:
  - restoring latest to a previous version
  - deleting the withdrawn Docker tags
  - deleting the GitHub release and tag
- Add concise withdrawal guidance and test coverage.