### PR TITLE
Fix install guide child indexing

### DIFF
--- a/embedding-generation/README.md
+++ b/embedding-generation/README.md
@@ -72,6 +72,11 @@ Example Docs,CC4.0,Example Arm Guide,https://example.com/arm-guide,arm; migratio
 
 Use clear keywords that users might include in questions. The `URL` is also what retrieval eval uses for expected matches.
 
+For multi-page Learn install guides, add only the parent guide URL. The
+generator discovers direct child pages from the guide's selection cards,
+chunks each child through the standard document pipeline, and preserves the
+child's canonical URL in the generated metadata.
+
 ## Discover developer.arm.com Sources
 
 `discover-developer-arm-com-sources.py` searches developer.arm.com and appends any new relevant pages (currently SME-related guides, programmer's guides, and blog posts) to `vector-db-sources.csv`. Existing rows are never modified, so it is safe to re-run occasionally to pick up new content.

--- a/embedding-generation/README.md
+++ b/embedding-generation/README.md
@@ -72,11 +72,6 @@ Example Docs,CC4.0,Example Arm Guide,https://example.com/arm-guide,arm; migratio
 
 Use clear keywords that users might include in questions. The `URL` is also what retrieval eval uses for expected matches.
 
-For multi-page Learn install guides, add only the parent guide URL. The
-generator discovers direct child pages from the guide's selection cards,
-chunks each child through the standard document pipeline, and preserves the
-child's canonical URL in the generated metadata.
-
 ## Discover developer.arm.com Sources
 
 `discover-developer-arm-com-sources.py` searches developer.arm.com and appends any new relevant pages (currently SME-related guides, programmer's guides, and blog posts) to `vector-db-sources.csv`. Existing rows are never modified, so it is safe to re-run occasionally to pick up new content.

--- a/embedding-generation/document_chunking.py
+++ b/embedding-generation/document_chunking.py
@@ -107,6 +107,15 @@ def is_learn_learning_path_url(url: str) -> bool:
     )
 
 
+def is_learn_install_guide_url(url: str) -> bool:
+    parsed = urlparse(normalize_source_url(url))
+    return (
+        parsed.scheme in {"http", "https"}
+        and parsed.netloc.lower() == "learn.arm.com"
+        and parsed.path.startswith("/install-guides/")
+    )
+
+
 def learn_learning_path_step_urls(source_url: str, html: str | bytes) -> list[str]:
     source_url = normalize_source_url(source_url)
     if not is_learn_learning_path_url(source_url):
@@ -135,6 +144,37 @@ def learn_learning_path_step_urls(source_url: str, html: str | bytes) -> list[st
             step_urls.append(step_url)
 
     return step_urls
+
+
+def learn_install_guide_child_urls(source_url: str, html: str | bytes) -> list[str]:
+    """Return child pages selected by a Learn multi-page install guide."""
+    source_url = normalize_source_url(source_url)
+    if not is_learn_install_guide_url(source_url):
+        return []
+
+    source = urlparse(source_url)
+    source_path = source.path.rstrip("/") + "/"
+    soup = BeautifulSoup(html, "html.parser")
+    child_urls: list[str] = []
+    seen: set[str] = set()
+
+    for card in soup.find_all(class_="multi-install-card"):
+        candidate = normalize_source_url(urljoin(source_url, card.get("link") or ""))
+        parsed = urlparse(candidate)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or parsed.netloc.lower() != "learn.arm.com"
+        ):
+            continue
+        path = parsed.path.rstrip("/") + "/"
+        if path == source_path or not path.startswith(source_path):
+            continue
+        child_url = urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+        if child_url not in seen:
+            seen.add(child_url)
+            child_urls.append(child_url)
+
+    return child_urls
 
 
 def is_arm_developer_documentation_url(url: str) -> bool:

--- a/embedding-generation/document_chunking.py
+++ b/embedding-generation/document_chunking.py
@@ -167,7 +167,10 @@ def learn_install_guide_child_urls(source_url: str, html: str | bytes) -> list[s
         ):
             continue
         path = parsed.path.rstrip("/") + "/"
-        if path == source_path or not path.startswith(source_path):
+        if not path.startswith(source_path):
+            continue
+        relative_path = path[len(source_path) :].strip("/")
+        if not relative_path or "/" in relative_path:
             continue
         child_url = urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
         if child_url not in seen:

--- a/embedding-generation/generate-chunks.py
+++ b/embedding-generation/generate-chunks.py
@@ -34,6 +34,7 @@ from document_chunking import (
     derive_product,
     derive_version,
     is_arm_developer_documentation_url,
+    learn_install_guide_child_urls,
     learn_learning_path_step_urls,
     normalize_source_url,
     parse_arm_documentation_api_json,
@@ -1010,12 +1011,16 @@ def create_chunks_for_source(
         return []
 
     sources_to_parse = [(normalized_source_url, response)]
-    for step_url in learn_learning_path_step_urls(
+    nested_urls = learn_learning_path_step_urls(
         normalized_source_url, response.content
-    ):
-        step_response = fetch_with_logging(source_to_fetch_url(step_url))
-        if step_response is not None:
-            sources_to_parse.append((step_url, step_response))
+    )
+    nested_urls.extend(
+        learn_install_guide_child_urls(normalized_source_url, response.content)
+    )
+    for nested_url in nested_urls:
+        nested_response = fetch_with_logging(source_to_fetch_url(nested_url))
+        if nested_response is not None:
+            sources_to_parse.append((nested_url, nested_response))
 
     keywords = parse_keywords(keywords_value, source_name)
     chunks = []

--- a/embedding-generation/tests/test_generate_chunks.py
+++ b/embedding-generation/tests/test_generate_chunks.py
@@ -383,6 +383,7 @@ class TestDocumentChunkingAnchors:
             b"<ads-card class='multi-install-card' link='/install-guides/browsers/chrome/'>Chrome</ads-card>"
             b"<ads-card class='multi-install-card' link='/install-guides/browsers/chrome/#install'>Chrome</ads-card>"
             b"<ads-card class='multi-install-card' link='/install-guides/browsers/firefox/'>Firefox</ads-card>"
+            b"<ads-card class='multi-install-card' link='/install-guides/browsers/chrome/linux/'>Nested</ads-card>"
             b"<ads-card class='multi-install-card' link='/install-guides/docker/docker-engine/'>Docker</ads-card>"
             b"<ads-card class='multi-install-card' link='https://example.com/browser/'>External</ads-card>"
             b"</main>"

--- a/embedding-generation/tests/test_generate_chunks.py
+++ b/embedding-generation/tests/test_generate_chunks.py
@@ -27,6 +27,7 @@ from urllib.parse import urlparse
 
 from document_chunking import (
     chunk_parsed_document,
+    learn_install_guide_child_urls,
     learn_learning_path_step_urls,
     parse_document_content,
 )
@@ -375,6 +376,72 @@ class TestDocumentChunkingAnchors:
         ) == [
             "https://learn.arm.com/learning-paths/cross-platform/example/1-get-started/"
         ]
+
+    def test_learn_install_guide_child_urls_discovers_multi_install_cards(self):
+        html = (
+            b"<main>"
+            b"<ads-card class='multi-install-card' link='/install-guides/browsers/chrome/'>Chrome</ads-card>"
+            b"<ads-card class='multi-install-card' link='/install-guides/browsers/chrome/#install'>Chrome</ads-card>"
+            b"<ads-card class='multi-install-card' link='/install-guides/browsers/firefox/'>Firefox</ads-card>"
+            b"<ads-card class='multi-install-card' link='/install-guides/docker/docker-engine/'>Docker</ads-card>"
+            b"<ads-card class='multi-install-card' link='https://example.com/browser/'>External</ads-card>"
+            b"</main>"
+        )
+
+        assert learn_install_guide_child_urls(
+            "https://learn.arm.com/install-guides/browsers/",
+            html,
+        ) == [
+            "https://learn.arm.com/install-guides/browsers/chrome/",
+            "https://learn.arm.com/install-guides/browsers/firefox/",
+        ]
+
+    def test_create_chunks_for_source_includes_multi_page_install_guide_children(self, gc, monkeypatch):
+        parent_url = "https://learn.arm.com/install-guides/browsers/"
+        chrome_url = "https://learn.arm.com/install-guides/browsers/chrome/"
+        firefox_url = "https://learn.arm.com/install-guides/browsers/firefox/"
+        responses = {
+            parent_url: SimpleNamespace(
+                url=parent_url,
+                content=(
+                    b"<main><h1>Install a browser</h1>"
+                    b"<p>Select a browser to view its installation instructions.</p>"
+                    b"<ads-card class='multi-install-card' link='/install-guides/browsers/chrome/'>Chrome</ads-card>"
+                    b"<ads-card class='multi-install-card' link='/install-guides/browsers/firefox/'>Firefox</ads-card>"
+                    b"</main>"
+                ),
+                headers={"content-type": "text/html"},
+            ),
+            chrome_url: SimpleNamespace(
+                url=chrome_url,
+                content=b"<main><h1>Install Chrome</h1><p>Download and install Chrome on Windows on Arm.</p></main>",
+                headers={"content-type": "text/html"},
+            ),
+            firefox_url: SimpleNamespace(
+                url=firefox_url,
+                content=b"<main><h1>Install Firefox</h1><p>Download and install Firefox on Windows on Arm.</p></main>",
+                headers={"content-type": "text/html"},
+            ),
+        }
+        fetched_urls = []
+
+        def fake_fetch(url):
+            fetched_urls.append(url)
+            return responses[url]
+
+        monkeypatch.setattr(gc, "fetch_with_logging", fake_fetch)
+
+        chunks = gc.create_chunks_for_source(
+            source_url=parent_url,
+            source_name="Install Guide - Browsers",
+            doc_type="Install Guide",
+            keywords_value="browsers; install",
+        )
+
+        assert fetched_urls == [parent_url, chrome_url, firefox_url]
+        chunk_urls = {chunk.url for chunk in chunks}
+        assert chrome_url in chunk_urls
+        assert firefox_url in chunk_urls
 
     def test_html_table_under_heading_is_returned_as_anchor_chunk(self):
         parsed = parse_document_content(


### PR DESCRIPTION
**Summary**
Fixes missing child pages from multi-page Learn install guides.
The chunking pipeline previously indexed only the parent guide. It now discovers and chunks direct child pages while preserving their canonical URLs.
Examples now indexed:
- /install-guides/browsers/chrome/
- /install-guides/docker/docker-engine/
- /install-guides/docker/docker-desktop/

**Testing**
- 63 tests passed
- Ruff passed
- Embedding Docker image built successfully
- Verified against the live Browsers and Docker pages